### PR TITLE
Modify find command to find a person by any fields except address

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Arrays;
 
 /**
  * Helper functions for handling strings.
@@ -21,7 +20,7 @@ public class StringUtil {
      *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
      *       </pre>
      * @param sentence cannot be null
-     * @param word cannot be null, cannot be empty, must be a single word
+     * @param word cannot be null, cannot be empty
      */
     public static boolean containsWordIgnoreCase(String sentence, String word) {
         requireNonNull(sentence);
@@ -29,10 +28,8 @@ public class StringUtil {
 
         String preppedWord = word.trim();
         checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
-        String[] wordsInPreppedSentence = {sentence};
 
-        return Arrays.stream(wordsInPreppedSentence)
-                .anyMatch(preppedWord::equalsIgnoreCase);
+        return sentence.toLowerCase().contains(preppedWord.toLowerCase());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -10,13 +10,20 @@ import seedu.address.commons.util.PredicateUtil;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.LicenceContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NricContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyExpiryContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyIssueContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyNumberContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Keyword matching is case-insensitive.
  */
 public class FindCommand extends Command {
 
@@ -29,6 +36,13 @@ public class FindCommand extends Command {
 
     private final NameContainsKeywordsPredicate namePredicate;
     private final LicenceContainsKeywordsPredicate licencePredicate;
+    private final NricContainsKeywordsPredicate nricPredicate;
+    private final PhoneContainsKeywordsPredicate phonePredicate;
+    private final PolicyNumberContainsKeywordsPredicate policyNumberPredicate;
+    private final TagContainsKeywordsPredicate tagPredicate;
+    private final PolicyExpiryContainsKeywordsPredicate policyExpiryPredicate;
+    private final EmailContainsKeywordsPredicate emailPredicate;
+    private final PolicyIssueContainsKeywordsPredicate policyIssuePredicate;
 
     /**
      * Constructor for FindCommand
@@ -37,15 +51,29 @@ public class FindCommand extends Command {
      * @param licencePredicate the predicate to be used for finding by licence plate number
      */
     public FindCommand(NameContainsKeywordsPredicate namePredicate,
-                       LicenceContainsKeywordsPredicate licencePredicate) {
+                       LicenceContainsKeywordsPredicate licencePredicate,
+                       NricContainsKeywordsPredicate nricPredicate,
+                       PhoneContainsKeywordsPredicate phonePredicate,
+                       PolicyNumberContainsKeywordsPredicate policyNumberPredicate,
+                       TagContainsKeywordsPredicate tagPredicate,
+                       PolicyExpiryContainsKeywordsPredicate policyExpiryPredicate,
+                       EmailContainsKeywordsPredicate emailPredicate,
+                       PolicyIssueContainsKeywordsPredicate policyIssuePredicate) {
         this.namePredicate = namePredicate;
         this.licencePredicate = licencePredicate;
+        this.nricPredicate = nricPredicate;
+        this.phonePredicate = phonePredicate;
+        this.policyNumberPredicate = policyNumberPredicate;
+        this.tagPredicate = tagPredicate;
+        this.policyExpiryPredicate = policyExpiryPredicate;
+        this.emailPredicate = emailPredicate;
+        this.policyIssuePredicate = policyIssuePredicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        List<Predicate<Person>> predicates = addToPredicateList(namePredicate, licencePredicate);
+        List<Predicate<Person>> predicates = addAllToPredicatesList();
         model.updateFilteredPersonList(PredicateUtil.combinePredicates(predicates));
 
         return new CommandResult(
@@ -73,11 +101,17 @@ public class FindCommand extends Command {
         return new ToStringBuilder(this)
                 .add("name predicate", namePredicate)
                 .add("licence predicate", licencePredicate)
+                .add("nric predicate", nricPredicate)
+                .add("phone predicate", phonePredicate)
+                .add("policy number predicate", policyNumberPredicate)
+                .add("tag predicate", tagPredicate)
+                .add("policy expiry predicate", policyExpiryPredicate)
+                .add("email predicate", emailPredicate)
+                .add("policy issue predicate", policyIssuePredicate)
                 .toString();
     }
 
-    private List<Predicate<Person>> addToPredicateList(
-            NameContainsKeywordsPredicate namePredicate, LicenceContainsKeywordsPredicate licencePredicate) {
+    private List<Predicate<Person>> addAllToPredicatesList() {
         List<Predicate<Person>> predicates = new ArrayList<>();
 
         if (!namePredicate.isEmpty()) {
@@ -85,6 +119,27 @@ public class FindCommand extends Command {
         }
         if (!licencePredicate.isEmpty()) {
             predicates.add(licencePredicate);
+        }
+        if (!nricPredicate.isEmpty()) {
+            predicates.add(nricPredicate);
+        }
+        if (!phonePredicate.isEmpty()) {
+            predicates.add(phonePredicate);
+        }
+        if (!policyNumberPredicate.isEmpty()) {
+            predicates.add(policyNumberPredicate);
+        }
+        if (!tagPredicate.isEmpty()) {
+            predicates.add(tagPredicate);
+        }
+        if (!policyExpiryPredicate.isEmpty()) {
+            predicates.add(policyExpiryPredicate);
+        }
+        if (!emailPredicate.isEmpty()) {
+            predicates.add(emailPredicate);
+        }
+        if (!policyIssuePredicate.isEmpty()) {
+            predicates.add(policyIssuePredicate);
         }
         return predicates;
     }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LICENCE_PLATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -12,18 +11,22 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_ISSUE_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_NUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Arrays;
-
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.LicenceContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NricContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyExpiryContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyIssueContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyNumberContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
-
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
@@ -38,27 +41,61 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG,
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TAG,
                         PREFIX_NRIC, PREFIX_LICENCE_PLATE, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
                         PREFIX_POLICY_EXPIRY_DATE);
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                PREFIX_TAG, PREFIX_NRIC, PREFIX_LICENCE_PLATE, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TAG,
+                PREFIX_NRIC, PREFIX_LICENCE_PLATE, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
                 PREFIX_POLICY_EXPIRY_DATE);
 
-        String[] nameKeyword = {""};
-        String[] licenceKeyword = {""};
+        String nameKeyword = "";
+        String licenceKeyword = "";
+        String nricKeyword = "";
+        String phoneKeyword = "";
+        String policyNumberKeyword = "";
+        String tagKeyword = "";
+        String policyExpiryKeyword = "";
+        String emailKeyword = "";
+        String policyIssueKeyword = "";
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            nameKeyword[0] = argMultimap.getValue(PREFIX_NAME).get();
+            nameKeyword = argMultimap.getValue(PREFIX_NAME).get();
         }
-
         if (argMultimap.getValue(PREFIX_LICENCE_PLATE).isPresent()) {
-            licenceKeyword[0] = argMultimap.getValue(PREFIX_LICENCE_PLATE).get();
+            licenceKeyword = argMultimap.getValue(PREFIX_LICENCE_PLATE).get();
+        }
+        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+            nricKeyword = argMultimap.getValue(PREFIX_NRIC).get();
+        }
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            phoneKeyword = argMultimap.getValue(PREFIX_PHONE).get();
+        }
+        if (argMultimap.getValue(PREFIX_POLICY_NUMBER).isPresent()) {
+            policyNumberKeyword = argMultimap.getValue(PREFIX_POLICY_NUMBER).get();
+        }
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            tagKeyword = argMultimap.getValue(PREFIX_TAG).get();
+        }
+        if (argMultimap.getValue(PREFIX_POLICY_EXPIRY_DATE).isPresent()) {
+            policyExpiryKeyword = argMultimap.getValue(PREFIX_POLICY_EXPIRY_DATE).get();
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            emailKeyword = argMultimap.getValue(PREFIX_EMAIL).get();
+        }
+        if (argMultimap.getValue(PREFIX_POLICY_ISSUE_DATE).isPresent()) {
+            policyIssueKeyword = argMultimap.getValue(PREFIX_POLICY_ISSUE_DATE).get();
         }
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeyword)),
-                new LicenceContainsKeywordsPredicate(Arrays.asList(licenceKeyword)));
+        return new FindCommand(new NameContainsKeywordsPredicate(nameKeyword),
+                new LicenceContainsKeywordsPredicate(licenceKeyword),
+                new NricContainsKeywordsPredicate(nricKeyword),
+                new PhoneContainsKeywordsPredicate(phoneKeyword),
+                new PolicyNumberContainsKeywordsPredicate(policyNumberKeyword),
+                new TagContainsKeywordsPredicate(tagKeyword),
+                new PolicyExpiryContainsKeywordsPredicate(policyExpiryKeyword),
+                new EmailContainsKeywordsPredicate(emailKeyword),
+                new PolicyIssueContainsKeywordsPredicate(policyIssueKeyword));
     }
 
 }

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -1,0 +1,34 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Email} matches any of the keywords given.
+ */
+public class EmailContainsKeywordsPredicate extends FieldPredicates {
+
+    public EmailContainsKeywordsPredicate(String keyword) {
+        super(keyword);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EmailContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        EmailContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (EmailContainsKeywordsPredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+    }
+}

--- a/src/main/java/seedu/address/model/person/FieldPredicates.java
+++ b/src/main/java/seedu/address/model/person/FieldPredicates.java
@@ -1,0 +1,41 @@
+package seedu.address.model.person;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+
+/**
+ * An abstract class to represent a Predicate
+ * Subclasses must implement the abstract methods to test for the Predicate
+ */
+public abstract class FieldPredicates implements Predicate<Person> {
+
+    protected final List<String> keywords;
+
+    public FieldPredicates(String keyword) {
+        keywords = Collections.singletonList(keyword);
+    }
+
+    @Override
+    public abstract boolean test(Person person);
+
+    @Override
+    public abstract boolean equals(Object other);
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+
+    /**
+     * Checks if the list of keywords in the predicate contain an empty string.
+     *
+     * @return true if the list of keywords contain an empty string, false otherwise.
+     */
+    public boolean isEmpty() {
+        return keywords.contains("");
+    }
+}

--- a/src/main/java/seedu/address/model/person/LicenceContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/LicenceContainsKeywordsPredicate.java
@@ -1,19 +1,13 @@
 package seedu.address.model.person;
 
-import java.util.List;
-import java.util.function.Predicate;
-
 import seedu.address.commons.util.StringUtil;
-import seedu.address.commons.util.ToStringBuilder;
 
 /**
  * Tests that a {@code Person}'s {@code Licence Plate} matches any of the keywords given.
  */
-public class LicenceContainsKeywordsPredicate implements Predicate<Person> {
-    private final List<String> keywords;
-
-    public LicenceContainsKeywordsPredicate(List<String> keywords) {
-        this.keywords = keywords;
+public class LicenceContainsKeywordsPredicate extends FieldPredicates {
+    public LicenceContainsKeywordsPredicate(String keyword) {
+        super(keyword);
     }
 
     @Override
@@ -35,19 +29,5 @@ public class LicenceContainsKeywordsPredicate implements Predicate<Person> {
 
         LicenceContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (LicenceContainsKeywordsPredicate) other;
         return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
-    }
-
-    @Override
-    public String toString() {
-        return new ToStringBuilder(this).add("keywords", keywords).toString();
-    }
-
-    /**
-     * Checks if the list of keywords contain an empty string.
-     *
-     * @return true if the list of keywords contain an empty string, false otherwise.
-     */
-    public boolean isEmpty() {
-        return keywords.contains("");
     }
 }

--- a/src/main/java/seedu/address/model/person/NricContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NricContainsKeywordsPredicate.java
@@ -3,17 +3,18 @@ package seedu.address.model.person;
 import seedu.address.commons.util.StringUtil;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code NRIC} matches any of the keywords given.
  */
-public class NameContainsKeywordsPredicate extends FieldPredicates {
-    public NameContainsKeywordsPredicate(String keyword) {
+public class NricContainsKeywordsPredicate extends FieldPredicates {
+
+    public NricContainsKeywordsPredicate(String keyword) {
         super(keyword);
     }
 
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getNric().value, keyword));
     }
 
     @Override
@@ -23,11 +24,11 @@ public class NameContainsKeywordsPredicate extends FieldPredicates {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof NameContainsKeywordsPredicate)) {
+        if (!(other instanceof NricContainsKeywordsPredicate)) {
             return false;
         }
 
-        NameContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;
+        NricContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (NricContainsKeywordsPredicate) other;
         return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
     }
 }

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -1,0 +1,34 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Phone Number} matches any of the keywords given.
+ */
+public class PhoneContainsKeywordsPredicate extends FieldPredicates {
+
+    public PhoneContainsKeywordsPredicate(String keyword) {
+        super(keyword);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof PhoneContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        PhoneContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (PhoneContainsKeywordsPredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+    }
+}

--- a/src/main/java/seedu/address/model/person/PolicyExpiryContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PolicyExpiryContainsKeywordsPredicate.java
@@ -1,0 +1,36 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Policy Expiry date} matches any of the keywords given.
+ */
+public class PolicyExpiryContainsKeywordsPredicate extends FieldPredicates {
+
+    public PolicyExpiryContainsKeywordsPredicate(String keyword) {
+        super(keyword);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
+                        person.getPolicy().getPolicyExpiryDate().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof PolicyExpiryContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        PolicyExpiryContainsKeywordsPredicate otherNameContainsKeywordsPredicate =
+                (PolicyExpiryContainsKeywordsPredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+    }
+}

--- a/src/main/java/seedu/address/model/person/PolicyIssueContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PolicyIssueContainsKeywordsPredicate.java
@@ -1,0 +1,36 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Policy Issue date} matches any of the keywords given.
+ */
+public class PolicyIssueContainsKeywordsPredicate extends FieldPredicates {
+
+    public PolicyIssueContainsKeywordsPredicate(String keyword) {
+        super(keyword);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
+                        person.getPolicy().getPolicyIssueDate().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof PolicyIssueContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        PolicyIssueContainsKeywordsPredicate otherNameContainsKeywordsPredicate =
+                (PolicyIssueContainsKeywordsPredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+    }
+}

--- a/src/main/java/seedu/address/model/person/PolicyNumberContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PolicyNumberContainsKeywordsPredicate.java
@@ -1,0 +1,36 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.StringUtil;
+
+
+/**
+ * Tests that a {@code Person}'s {@code Policy Number} matches any of the keywords given.
+ */
+public class PolicyNumberContainsKeywordsPredicate extends FieldPredicates {
+    public PolicyNumberContainsKeywordsPredicate(String keyword) {
+        super(keyword);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
+                        person.getPolicy().getPolicyNumber().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof PolicyNumberContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        PolicyNumberContainsKeywordsPredicate otherNameContainsKeywordsPredicate =
+                (PolicyNumberContainsKeywordsPredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+    }
+}

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -1,0 +1,34 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Tags} matches any of the keywords given.
+ */
+public class TagContainsKeywordsPredicate extends FieldPredicates {
+    public TagContainsKeywordsPredicate(String keyword) {
+        super(keyword);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> person.getTags().stream().anyMatch(
+                        tag -> StringUtil.containsWordIgnoreCase(tag.tagName, keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TagContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        TagContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (TagContainsKeywordsPredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -130,8 +129,7 @@ public class CommandTestUtil {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
 
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
-        final String[] splitName = {person.getName().fullName};
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(person.getName().fullName));
 
         assertEquals(1, model.getFilteredPersonList().size());
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
@@ -15,8 +14,15 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.LicenceContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NricContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyExpiryContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyIssueContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyNumberContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -25,23 +31,60 @@ public class FindCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-    private LicenceContainsKeywordsPredicate dummyLicence =
-            new LicenceContainsKeywordsPredicate(Collections.singletonList(""));
-
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
-        FindCommand findFirstCommand = new FindCommand(firstPredicate, dummyLicence);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate, dummyLicence);
+        NameContainsKeywordsPredicate firstNamePredicate =
+                new NameContainsKeywordsPredicate("first");
+        NameContainsKeywordsPredicate secondNamePredicate =
+                new NameContainsKeywordsPredicate("second");
+        LicenceContainsKeywordsPredicate firstLicencePredicate =
+                new LicenceContainsKeywordsPredicate("SAA1A");
+        LicenceContainsKeywordsPredicate secondLicencePredicate =
+                new LicenceContainsKeywordsPredicate("SAA1B");
+        NricContainsKeywordsPredicate firstNricPredicate =
+                new NricContainsKeywordsPredicate("000A");
+        NricContainsKeywordsPredicate secondNricPredicate =
+                new NricContainsKeywordsPredicate("000B");
+        PhoneContainsKeywordsPredicate firstPhonePredicate =
+                new PhoneContainsKeywordsPredicate("12345678");
+        PhoneContainsKeywordsPredicate secondPhonePredicate =
+                new PhoneContainsKeywordsPredicate("87654321");
+        PolicyNumberContainsKeywordsPredicate firstPolicyNumPredicate =
+                new PolicyNumberContainsKeywordsPredicate("A1234");
+        PolicyNumberContainsKeywordsPredicate secondPolicyNumPredicate =
+                new PolicyNumberContainsKeywordsPredicate("B4321");
+        TagContainsKeywordsPredicate firstTagPredicate =
+                new TagContainsKeywordsPredicate("friends");
+        TagContainsKeywordsPredicate secondTagPredicate =
+                new TagContainsKeywordsPredicate("colleagues");
+        PolicyExpiryContainsKeywordsPredicate firstPolicyExpiryPredicate =
+                new PolicyExpiryContainsKeywordsPredicate("25-12-2023");
+        PolicyExpiryContainsKeywordsPredicate secondPolicyExpiryPredicate =
+                new PolicyExpiryContainsKeywordsPredicate("14-02-2023");
+        EmailContainsKeywordsPredicate firstEmailPredicate =
+                new EmailContainsKeywordsPredicate("weewooowaa@example.com");
+        EmailContainsKeywordsPredicate secondEmailPredicate =
+                new EmailContainsKeywordsPredicate("heehoohaa@example.com");
+        PolicyIssueContainsKeywordsPredicate firstPolicyIssuePredicate =
+                new PolicyIssueContainsKeywordsPredicate("12-12-2022");
+        PolicyIssueContainsKeywordsPredicate secondPolicyIssuePredicate =
+                new PolicyIssueContainsKeywordsPredicate("11-11-2022");
+
+
+        FindCommand findFirstCommand = new FindCommand(firstNamePredicate, firstLicencePredicate,
+                firstNricPredicate, firstPhonePredicate, firstPolicyNumPredicate, firstTagPredicate,
+                firstPolicyExpiryPredicate, firstEmailPredicate, firstPolicyIssuePredicate);
+        FindCommand findSecondCommand = new FindCommand(secondNamePredicate, secondLicencePredicate,
+                secondNricPredicate, secondPhonePredicate, secondPolicyNumPredicate, secondTagPredicate,
+                secondPolicyExpiryPredicate, secondEmailPredicate, secondPolicyIssuePredicate);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate, dummyLicence);
+        FindCommand findFirstCommandCopy = new FindCommand(firstNamePredicate, firstLicencePredicate,
+                firstNricPredicate, firstPhonePredicate, firstPolicyNumPredicate, firstTagPredicate,
+                firstPolicyExpiryPredicate, firstEmailPredicate, firstPolicyIssuePredicate);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -55,10 +98,27 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() {
+    public void execute_noMatchingKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate, dummyLicence);
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate("test");
+        LicenceContainsKeywordsPredicate licencePredicate =
+                new LicenceContainsKeywordsPredicate("SAA1B");
+        NricContainsKeywordsPredicate nricPredicate =
+                new NricContainsKeywordsPredicate("000A");
+        PhoneContainsKeywordsPredicate phonePredicate =
+                new PhoneContainsKeywordsPredicate("12345678");
+        PolicyNumberContainsKeywordsPredicate policyNumPredicate =
+                new PolicyNumberContainsKeywordsPredicate("A1234");
+        TagContainsKeywordsPredicate tagPredicate =
+                new TagContainsKeywordsPredicate("friends");
+        PolicyExpiryContainsKeywordsPredicate policyExpiryPredicate =
+                new PolicyExpiryContainsKeywordsPredicate("25-12-2023");
+        EmailContainsKeywordsPredicate emailPredicate =
+                new EmailContainsKeywordsPredicate("weewooowaa@example.com");
+        PolicyIssueContainsKeywordsPredicate policyIssuePredicate =
+                new PolicyIssueContainsKeywordsPredicate("12-12-2022");
+        FindCommand command = new FindCommand(predicate, licencePredicate, nricPredicate, phonePredicate,
+                policyNumPredicate, tagPredicate, policyExpiryPredicate, emailPredicate, policyIssuePredicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
@@ -66,10 +126,30 @@ public class FindCommandTest {
 
     @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
-        FindCommand findCommand = new FindCommand(predicate, dummyLicence);
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate("keyword");
+        LicenceContainsKeywordsPredicate licencePredicate =
+                new LicenceContainsKeywordsPredicate("SAA1B");
+        NricContainsKeywordsPredicate nricPredicate =
+                new NricContainsKeywordsPredicate("000A");
+        PhoneContainsKeywordsPredicate phonePredicate =
+                new PhoneContainsKeywordsPredicate("12345678");
+        PolicyNumberContainsKeywordsPredicate policyNumPredicate =
+                new PolicyNumberContainsKeywordsPredicate("A1234");
+        TagContainsKeywordsPredicate tagPredicate =
+                new TagContainsKeywordsPredicate("friends");
+        PolicyExpiryContainsKeywordsPredicate policyExpiryPredicate =
+                new PolicyExpiryContainsKeywordsPredicate("25-12-2023");
+        EmailContainsKeywordsPredicate emailPredicate =
+                new EmailContainsKeywordsPredicate("weewooowaa@example.com");
+        PolicyIssueContainsKeywordsPredicate policyIssuePredicate =
+                new PolicyIssueContainsKeywordsPredicate("12-12-2022");
+        FindCommand findCommand = new FindCommand(predicate, licencePredicate, nricPredicate, phonePredicate,
+                policyNumPredicate, tagPredicate, policyExpiryPredicate, emailPredicate, policyIssuePredicate);
         String expected = FindCommand.class.getCanonicalName() + "{name predicate=" + predicate
-                + ", licence predicate=" + dummyLicence + "}";
+                + ", licence predicate=" + licencePredicate + ", nric predicate=" + nricPredicate
+                + ", phone predicate=" + phonePredicate + ", policy number predicate=" + policyNumPredicate
+                + ", tag predicate=" + tagPredicate + ", policy expiry predicate=" + policyExpiryPredicate
+                + ", email predicate=" + emailPredicate + ", policy issue predicate=" + policyIssuePredicate + "}";
         assertEquals(expected, findCommand.toString());
     }
 
@@ -77,6 +157,6 @@ public class FindCommandTest {
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
     private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+        return new NameContainsKeywordsPredicate(userInput);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -7,11 +7,6 @@ import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.ClearCommand;
@@ -23,9 +18,16 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.LicenceContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NricContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyExpiryContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyIssueContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyNumberContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -73,11 +75,15 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo bar fun");
+        String keywords = "foo bar fun";
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " n/" + keywords.stream().collect(Collectors.joining(" ")));
+                FindCommand.COMMAND_WORD + " n/" + keywords);
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords),
-                new LicenceContainsKeywordsPredicate(Collections.singletonList(""))), command);
+                new LicenceContainsKeywordsPredicate(""),
+                new NricContainsKeywordsPredicate(""),
+                new PhoneContainsKeywordsPredicate(""), new PolicyNumberContainsKeywordsPredicate(""),
+                new TagContainsKeywordsPredicate(""), new PolicyExpiryContainsKeywordsPredicate(""),
+                new EmailContainsKeywordsPredicate(""), new PolicyIssueContainsKeywordsPredicate("")), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -4,14 +4,18 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Arrays;
-import java.util.Collections;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.LicenceContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NricContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyExpiryContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyIssueContainsKeywordsPredicate;
+import seedu.address.model.person.PolicyNumberContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -26,8 +30,11 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice Bob")),
-                        new LicenceContainsKeywordsPredicate(Collections.singletonList("")));
+                new FindCommand(new NameContainsKeywordsPredicate("Alice Bob"),
+                        new LicenceContainsKeywordsPredicate(""), new NricContainsKeywordsPredicate(""),
+                        new PhoneContainsKeywordsPredicate(""), new PolicyNumberContainsKeywordsPredicate(""),
+                        new TagContainsKeywordsPredicate(""), new PolicyExpiryContainsKeywordsPredicate(""),
+                        new EmailContainsKeywordsPredicate(""), new PolicyIssueContainsKeywordsPredicate(""));
         assertParseSuccess(parser, "find n/Alice Bob", expectedFindCommand);
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -10,7 +10,6 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
@@ -117,8 +116,8 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs)));
 
         // different filteredList -> returns false
-        String[] keywords = ALICE.getName().fullName.split("\\s+");
-        modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        String keywords = ALICE.getName().fullName;
+        modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(keywords));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -4,10 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.PersonBuilder;
@@ -16,17 +12,17 @@ public class NameContainsKeywordsPredicateTest {
 
     @Test
     public void equals() {
-        List<String> firstPredicateKeywordList = Collections.singletonList("first");
-        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "first second";
 
-        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
-        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(secondPredicateKeywordList);
+        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(firstPredicateKeyword);
+        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(secondPredicateKeyword);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        NameContainsKeywordsPredicate firstPredicateCopy = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
+        NameContainsKeywordsPredicate firstPredicateCopy = new NameContainsKeywordsPredicate(firstPredicateKeyword);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -43,40 +39,35 @@ public class NameContainsKeywordsPredicateTest {
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
         NameContainsKeywordsPredicate predicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("Alice Bob"));
+                new NameContainsKeywordsPredicate("Alice Bob");
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Trailing and Leading white spaces
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("   Alice Bob    "));
+        predicate = new NameContainsKeywordsPredicate("   Alice Bob    ");
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Mixed-case keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce bOB"));
+        predicate = new NameContainsKeywordsPredicate("aLIce bOB");
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate("test");
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
 
         // Non-matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));
+        predicate = new NameContainsKeywordsPredicate("Carol");
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
-
-        // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
 
     @Test
     public void toStringMethod() {
-        List<String> keywords = List.of("keyword1", "keyword2");
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(keywords);
+        String keyword = "keyword1";
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(keyword);
 
-        String expected = NameContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        String expected = NameContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=[" + keyword + "]}";
         assertEquals(expected, predicate.toString());
     }
 }


### PR DESCRIPTION
Closes #62

Able to find a person based on the fields given. Even partial string matches such as:
1. `find n/Alex` will return names such as `Alex Yeoh`, `Alex Lam` as long as there is a `Alex` in the name

Also, made it work such that `find n/Alex Yeoh` will only return those persons whose name contains `Alex Yeoh` and not just any `Alex`

The same logic goes for the other fields as well. Specifying more than 1 field will yield more specific result:
1. `find n/Alex Yeoh l/SLA001B` will return those persons whose name contains `Alex Yeoh` and licence plate `SLA001B`