### PR TITLE
Handle exceptional cases that might occur while using the add command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,7 +18,17 @@ public class Messages {
 
     public static final String MESSAGE_IMPOSSIBLE_INDEX = "Error: The parameter is not of the type positive integer";
 
+    public static final String MESSAGE_PREAMBLE_DETECTED = "Error: Preamble Detected";
 
+    public static final String MESSAGE_MISSING_FIELDS_FOR_ADD_COMMAND =
+            "Error: Some of the required fields are missing. "
+            + "\n"
+            + "Please include the following: ";
+
+    public static final String MESSAGE_MISSING_FIELDS_POLICY_FOR_ADD_COMMAND =
+            "Please include either all or none of the policy variables. "
+            + "\n"
+            + "You are missing the following: ";
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -56,7 +56,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 PREFIX_LICENCE_PLATE, PREFIX_ADDRESS)) {
             String errorMessage = MESSAGE_MISSING_FIELDS_FOR_ADD_COMMAND;
             if (argMultimap.getValue(PREFIX_NAME).isEmpty()) {
-                errorMessage += "- Name("  + PREFIX_NAME + ") ";
+                errorMessage += "- Name(" + PREFIX_NAME + ") ";
             }
             if (argMultimap.getValue(PREFIX_PHONE).isEmpty()) {
                 errorMessage += "- Phone(" + PREFIX_PHONE + ") ";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -71,7 +71,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 errorMessage += "- License Plate(l/) ";
             }
             if (argMultimap.getValue(PREFIX_ADDRESS).isEmpty()) {
-                errorMessage += "- Address(a/) ";
+                errorMessage += "- Address(" + PREFIX_ADDRESS + ") ";
             }
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, errorMessage));
         }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -48,7 +48,28 @@ public class AddCommandParser implements Parser<AddCommand> {
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NRIC,
                 PREFIX_LICENCE_PLATE, PREFIX_ADDRESS)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            String errorMessage = "Error: Some of the required fields are missing. " +
+                    "\n"
+                    + "Please include the following: ";
+            if (argMultimap.getValue(PREFIX_NAME).isEmpty()) {
+                errorMessage += "- Name(n/) ";
+            }
+            if (argMultimap.getValue(PREFIX_PHONE).isEmpty()) {
+                errorMessage += "- Phone(p/) ";
+            }
+            if (argMultimap.getValue(PREFIX_EMAIL).isEmpty()) {
+                errorMessage += "- Email(e/) ";
+            }
+            if (argMultimap.getValue(PREFIX_NRIC).isEmpty()) {
+                errorMessage += "- NRIC(i/) ";
+            }
+            if (argMultimap.getValue(PREFIX_LICENCE_PLATE).isEmpty()) {
+                errorMessage += "- License Plate(I/) ";
+            }
+            if (argMultimap.getValue(PREFIX_ADDRESS).isEmpty()) {
+                errorMessage += "- Address(a/) ";
+            }
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, errorMessage));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NRIC,
@@ -60,6 +81,26 @@ public class AddCommandParser implements Parser<AddCommand> {
         LicencePlate licencePlate = ParserUtil.parseLicencePlate(argMultimap.getValue(PREFIX_LICENCE_PLATE).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        if (!arePrefixesAbsent(argMultimap, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
+                PREFIX_POLICY_EXPIRY_DATE)) {
+            if (!arePrefixesPresent(argMultimap, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
+                    PREFIX_POLICY_EXPIRY_DATE)) {
+                String errorMessage = "Please include either all or none of the policy variables. "
+                        + "\n"
+                        + "You are missing the following: ";
+                if (argMultimap.getValue(PREFIX_POLICY_NUMBER).isEmpty()) {
+                    errorMessage += "- Policy Number(pn/) ";
+                }
+                if (argMultimap.getValue(PREFIX_POLICY_ISSUE_DATE).isEmpty()) {
+                    errorMessage += "- Policy Issue Date(pi/) ";
+                }
+                if (argMultimap.getValue(PREFIX_POLICY_EXPIRY_DATE).isEmpty()) {
+                    errorMessage += "- Policy Expiry Date(pe/) ";
+                }
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, errorMessage));
+            }
+        }
 
         // temporary variables to change
         PolicyNumber policyNumber = new PolicyNumber(PolicyNumber.DEFAULT_VALUE);
@@ -87,6 +128,14 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Returns true if all of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesAbsent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isEmpty());
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_FIELDS_FOR_ADD_COMMAND;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_FIELDS_POLICY_FOR_ADD_COMMAND;
+import static seedu.address.logic.Messages.MESSAGE_PREAMBLE_DETECTED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LICENCE_PLATE;
@@ -46,14 +49,12 @@ public class AddCommandParser implements Parser<AddCommand> {
                         PREFIX_POLICY_ISSUE_DATE, PREFIX_POLICY_EXPIRY_DATE);
 
         if (!argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_PREAMBLE_DETECTED));
         }
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NRIC,
                 PREFIX_LICENCE_PLATE, PREFIX_ADDRESS)) {
-            String errorMessage = "Error: Some of the required fields are missing. "
-                    + "\n"
-                    + "Please include the following: ";
+            String errorMessage = MESSAGE_MISSING_FIELDS_FOR_ADD_COMMAND;
             if (argMultimap.getValue(PREFIX_NAME).isEmpty()) {
                 errorMessage += "- Name(n/) ";
             }
@@ -89,9 +90,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 PREFIX_POLICY_EXPIRY_DATE)) {
             if (!arePrefixesPresent(argMultimap, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
                     PREFIX_POLICY_EXPIRY_DATE)) {
-                String errorMessage = "Please include either all or none of the policy variables. "
-                        + "\n"
-                        + "You are missing the following: ";
+                String errorMessage = MESSAGE_MISSING_FIELDS_POLICY_FOR_ADD_COMMAND;
                 if (argMultimap.getValue(PREFIX_POLICY_NUMBER).isEmpty()) {
                     errorMessage += "- Policy Number(pn/) ";
                 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -95,7 +95,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                     errorMessage += "- Policy Number(" + PREFIX_POLICY_NUMBER + ") ";
                 }
                 if (argMultimap.getValue(PREFIX_POLICY_ISSUE_DATE).isEmpty()) {
-                    errorMessage += "- Policy Issue Date(pi/) ";
+                    errorMessage += "- Policy Issue Date(" + PREFIX_POLICY_ISSUE_DATE + ") ";
                 }
                 if (argMultimap.getValue(PREFIX_POLICY_EXPIRY_DATE).isEmpty()) {
                     errorMessage += "- Policy Expiry Date(" + PREFIX_POLICY_EXPIRY_DATE + ") ";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -56,7 +56,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 PREFIX_LICENCE_PLATE, PREFIX_ADDRESS)) {
             String errorMessage = MESSAGE_MISSING_FIELDS_FOR_ADD_COMMAND;
             if (argMultimap.getValue(PREFIX_NAME).isEmpty()) {
-                errorMessage += "- Name(n/) ";
+                errorMessage += "- Name("  + PREFIX_NAME + ") ";
             }
             if (argMultimap.getValue(PREFIX_PHONE).isEmpty()) {
                 errorMessage += "- Phone(p/) ";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -59,7 +59,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 errorMessage += "- Name("  + PREFIX_NAME + ") ";
             }
             if (argMultimap.getValue(PREFIX_PHONE).isEmpty()) {
-                errorMessage += "- Phone(p/) ";
+                errorMessage += "- Phone(" + PREFIX_PHONE + ") ";
             }
             if (argMultimap.getValue(PREFIX_EMAIL).isEmpty()) {
                 errorMessage += "- Email(e/) ";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -98,7 +98,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                     errorMessage += "- Policy Issue Date(pi/) ";
                 }
                 if (argMultimap.getValue(PREFIX_POLICY_EXPIRY_DATE).isEmpty()) {
-                    errorMessage += "- Policy Expiry Date(pe/) ";
+                    errorMessage += "- Policy Expiry Date(" + PREFIX_POLICY_EXPIRY_DATE + ") ";
                 }
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, errorMessage));
             }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -62,7 +62,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 errorMessage += "- Phone(" + PREFIX_PHONE + ") ";
             }
             if (argMultimap.getValue(PREFIX_EMAIL).isEmpty()) {
-                errorMessage += "- Email(" + PREFIX_EMAIL" + ") ";
+                errorMessage += "- Email(" + PREFIX_EMAIL + ") ";
             }
             if (argMultimap.getValue(PREFIX_NRIC).isEmpty()) {
                 errorMessage += "- NRIC(+ " PREFIX_NRIC + ") ";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -65,7 +65,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 errorMessage += "- Email(" + PREFIX_EMAIL + ") ";
             }
             if (argMultimap.getValue(PREFIX_NRIC).isEmpty()) {
-                errorMessage += "- NRIC(+ " PREFIX_NRIC + ") ";
+                errorMessage += "- NRIC(" + PREFIX_NRIC + ") ";
             }
             if (argMultimap.getValue(PREFIX_LICENCE_PLATE).isEmpty()) {
                 errorMessage += "- License Plate(" + PREFIX_LICENCE_PLATE + ") ";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -62,7 +62,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 errorMessage += "- Phone(" + PREFIX_PHONE + ") ";
             }
             if (argMultimap.getValue(PREFIX_EMAIL).isEmpty()) {
-                errorMessage += "- Email(e/) ";
+                errorMessage += "- Email(" + PREFIX_EMAIL" + ") ";
             }
             if (argMultimap.getValue(PREFIX_NRIC).isEmpty()) {
                 errorMessage += "- NRIC(i/) ";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -45,11 +45,14 @@ public class AddCommandParser implements Parser<AddCommand> {
                         PREFIX_LICENCE_PLATE, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_POLICY_NUMBER,
                         PREFIX_POLICY_ISSUE_DATE, PREFIX_POLICY_EXPIRY_DATE);
 
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        }
+
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NRIC,
-                PREFIX_LICENCE_PLATE, PREFIX_ADDRESS)
-                || !argMultimap.getPreamble().isEmpty()) {
-            String errorMessage = "Error: Some of the required fields are missing. " +
-                    "\n"
+                PREFIX_LICENCE_PLATE, PREFIX_ADDRESS)) {
+            String errorMessage = "Error: Some of the required fields are missing. "
+                    + "\n"
                     + "Please include the following: ";
             if (argMultimap.getValue(PREFIX_NAME).isEmpty()) {
                 errorMessage += "- Name(n/) ";
@@ -64,7 +67,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 errorMessage += "- NRIC(i/) ";
             }
             if (argMultimap.getValue(PREFIX_LICENCE_PLATE).isEmpty()) {
-                errorMessage += "- License Plate(I/) ";
+                errorMessage += "- License Plate(l/) ";
             }
             if (argMultimap.getValue(PREFIX_ADDRESS).isEmpty()) {
                 errorMessage += "- Address(a/) ";
@@ -102,7 +105,7 @@ public class AddCommandParser implements Parser<AddCommand> {
             }
         }
 
-        // temporary variables to change
+        // temporary variables for when no policy paramers were inputed
         PolicyNumber policyNumber = new PolicyNumber(PolicyNumber.DEFAULT_VALUE);
         PolicyDate policyIssueDate = new PolicyDate(PolicyDate.DEFAULT_VALUE);
         PolicyDate policyExpiryDate = new PolicyDate(PolicyDate.DEFAULT_VALUE);
@@ -115,6 +118,7 @@ public class AddCommandParser implements Parser<AddCommand> {
             policyIssueDate = ParserUtil.parsePolicyIssueDate(argMultimap.getValue(PREFIX_POLICY_ISSUE_DATE).get());
             policyExpiryDate = ParserUtil.parsePolicyExpiryDate(argMultimap.getValue(PREFIX_POLICY_EXPIRY_DATE).get());
         }
+
         Policy policy = new Policy(policyNumber, policyIssueDate, policyExpiryDate);
 
         Person person = new Person(name, phone, email, address, tagList, nric, licencePlate, policy);

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -68,7 +68,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 errorMessage += "- NRIC(i/) ";
             }
             if (argMultimap.getValue(PREFIX_LICENCE_PLATE).isEmpty()) {
-                errorMessage += "- License Plate(l/) ";
+                errorMessage += "- License Plate(" + PREFIX_LICENCE_PLATE + ") ";
             }
             if (argMultimap.getValue(PREFIX_ADDRESS).isEmpty()) {
                 errorMessage += "- Address(" + PREFIX_ADDRESS + ") ";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -92,7 +92,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                     PREFIX_POLICY_EXPIRY_DATE)) {
                 String errorMessage = MESSAGE_MISSING_FIELDS_POLICY_FOR_ADD_COMMAND;
                 if (argMultimap.getValue(PREFIX_POLICY_NUMBER).isEmpty()) {
-                    errorMessage += "- Policy Number(pn/) ";
+                    errorMessage += "- Policy Number(" + PREFIX_POLICY_NUMBER + ") ";
                 }
                 if (argMultimap.getValue(PREFIX_POLICY_ISSUE_DATE).isEmpty()) {
                     errorMessage += "- Policy Issue Date(pi/) ";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -65,7 +65,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 errorMessage += "- Email(" + PREFIX_EMAIL" + ") ";
             }
             if (argMultimap.getValue(PREFIX_NRIC).isEmpty()) {
-                errorMessage += "- NRIC(i/) ";
+                errorMessage += "- NRIC(+ " PREFIX_NRIC + ") ";
             }
             if (argMultimap.getValue(PREFIX_LICENCE_PLATE).isEmpty()) {
                 errorMessage += "- License Plate(" + PREFIX_LICENCE_PLATE + ") ";

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -27,10 +27,6 @@ import static seedu.address.logic.commands.CommandTestUtil.POLICY_NO_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
@@ -146,7 +142,7 @@ public class AddCommandParserTest {
     }
 
     @Test
-    public void parse_optionalFieldsMissing_success() {
+    public void parse_allOptionalFieldsPresent_success() {
         // zero tags
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
@@ -156,34 +152,67 @@ public class AddCommandParserTest {
     }
 
     @Test
+    public void parse_someButNotAllOptionalFieldsPresent_failure() {
+        String errorMessage = "Please include either all or none of the policy variables. "
+                + "\n"
+                + "You are missing the following: - Policy Expiry Date(pe/) ";
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, errorMessage);
+        assertParseFailure(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                        + NRIC_DESC_BOB + LICENSE_PLATE_DESC_BOB + ADDRESS_DESC_BOB
+                        + TAG_DESC_FRIEND + POLICY_NO_DESC_BOB + POLICY_ISSUE_DATE_DESC_BOB,
+                expectedMessage);
+    }
+
+
+    @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        String errorMessage = "Error: Some of the required fields are missing. "
+                + "\n"
+                + "Please include the following: ";
+
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, errorMessage);
 
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        assertParseFailure(parser,
+                PHONE_DESC_BOB + EMAIL_DESC_BOB + NRIC_DESC_BOB + LICENSE_PLATE_DESC_BOB + ADDRESS_DESC_BOB,
+                expectedMessage + "- Name(n/) ");
 
         // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        assertParseFailure(parser,
+                NAME_DESC_BOB + EMAIL_DESC_BOB + NRIC_DESC_BOB + LICENSE_PLATE_DESC_BOB + ADDRESS_DESC_BOB,
+                expectedMessage + "- Phone(p/) ");
 
         // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        assertParseFailure(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + NRIC_DESC_BOB + LICENSE_PLATE_DESC_BOB + ADDRESS_DESC_BOB,
+                expectedMessage + "- Email(e/) ");
+
+        // missing nric prefix
+        assertParseFailure(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + LICENSE_PLATE_DESC_BOB + ADDRESS_DESC_BOB,
+                expectedMessage + "- NRIC(i/) ");
+
+        //missing license plate prefix
+        assertParseFailure(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + NRIC_DESC_BOB + ADDRESS_DESC_BOB,
+                expectedMessage + "- License Plate(l/) ");
 
         // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
-                expectedMessage);
+        assertParseFailure(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + NRIC_DESC_BOB + EMAIL_DESC_BOB + LICENSE_PLATE_DESC_BOB,
+                expectedMessage + "- Address(a/) ");
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,
-                expectedMessage);
+        assertParseFailure(parser, "",
+                expectedMessage + "- Name(n/) - Phone(p/) - Email(e/) - NRIC(i/) - License Plate(l/) - Address(a/) ");
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + NRIC_DESC_BOB
+        assertParseFailure(parser,
+                INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + NRIC_DESC_BOB
                 + LICENSE_PLATE_DESC_BOB + ADDRESS_DESC_BOB
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_FIELDS_FOR_ADD_COMMAND;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_FIELDS_POLICY_FOR_ADD_COMMAND;
+import static seedu.address.logic.Messages.MESSAGE_PREAMBLE_DETECTED;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -153,9 +156,7 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_someButNotAllOptionalFieldsPresent_failure() {
-        String errorMessage = "Please include either all or none of the policy variables. "
-                + "\n"
-                + "You are missing the following: - Policy Expiry Date(pe/) ";
+        String errorMessage = MESSAGE_MISSING_FIELDS_POLICY_FOR_ADD_COMMAND + "- Policy Expiry Date(pe/) ";
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, errorMessage);
         assertParseFailure(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
@@ -167,9 +168,7 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String errorMessage = "Error: Some of the required fields are missing. "
-                + "\n"
-                + "Please include the following: ";
+        String errorMessage = MESSAGE_MISSING_FIELDS_FOR_ADD_COMMAND;
 
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, errorMessage);
 
@@ -244,6 +243,6 @@ public class AddCommandParserTest {
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + NRIC_DESC_BOB
                 + LICENSE_PLATE_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_PREAMBLE_DETECTED));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -35,4 +35,5 @@ public class DeleteCommandParserTest {
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(Messages.MESSAGE_IMPOSSIBLE_INDEX, DeleteCommand.MESSAGE_USAGE));
     }
+
 }


### PR DESCRIPTION
The program will specify which parameters are missing if an add command is incomplete.

The user is also now required to either include all or none of the policy variables when using the add command.

Closes #63 