### PR TITLE
Modify policy class to contain company

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -2,9 +2,15 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LICENCE_PLATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_EXPIRY_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_ISSUE_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_NUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -28,6 +34,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.policy.Company;
 import seedu.address.model.policy.Policy;
 import seedu.address.model.policy.PolicyDate;
 import seedu.address.model.policy.PolicyNumber;
@@ -49,6 +56,12 @@ public class EditCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_NRIC + "NRIC] "
+            + "[" + PREFIX_LICENCE_PLATE + "LICENCE_PLATE] "
+            + "[" + PREFIX_COMPANY + "COMPANY] "
+            + "[" + PREFIX_POLICY_NUMBER + "POLICY_NUMBER] "
+            + "[" + PREFIX_POLICY_ISSUE_DATE + "POLICY_ISSUE_DATE] "
+            + "[" + PREFIX_POLICY_EXPIRY_DATE + "POLICY_EXPIRY_DATE] "
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
@@ -115,13 +128,14 @@ public class EditCommand extends Command {
     }
 
     private static Policy getUpdatedPolicy(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
+        Company updatedCompany = editPersonDescriptor.getCompany().orElse(personToEdit.getPolicy().getCompany());
         PolicyNumber updatedPolicyNumber =
                 editPersonDescriptor.getPolicyNumber().orElse(personToEdit.getPolicy().getPolicyNumber());
         PolicyDate updatedPolicyIssueDate =
                 editPersonDescriptor.getPolicyIssueDate().orElse(personToEdit.getPolicy().getPolicyIssueDate());
         PolicyDate updatedPolicyExpiryDate =
                 editPersonDescriptor.getPolicyExpiryDate().orElse(personToEdit.getPolicy().getPolicyExpiryDate());
-        return new Policy(updatedPolicyNumber, updatedPolicyIssueDate, updatedPolicyExpiryDate);
+        return new Policy(updatedCompany, updatedPolicyNumber, updatedPolicyIssueDate, updatedPolicyExpiryDate);
     }
 
     @Override
@@ -160,6 +174,7 @@ public class EditCommand extends Command {
         private Set<Tag> tags;
         private Nric nric;
         private LicencePlate licencePlate;
+        private Company company;
         private PolicyNumber policyNumber;
         private PolicyDate policyIssueDate;
         private PolicyDate policyExpiryDate;
@@ -179,6 +194,7 @@ public class EditCommand extends Command {
             setTags(toCopy.tags);
             setNric(toCopy.nric);
             setLicencePlate(toCopy.licencePlate);
+            setCompany(toCopy.company);
             setPolicyNumber(toCopy.policyNumber);
             setPolicyIssueDate(toCopy.policyIssueDate);
             setPolicyExpiryDate(toCopy.policyExpiryDate);
@@ -196,6 +212,7 @@ public class EditCommand extends Command {
                     tags,
                     nric,
                     licencePlate,
+                    company,
                     policyNumber,
                     policyIssueDate,
                     policyExpiryDate
@@ -267,6 +284,14 @@ public class EditCommand extends Command {
             return Optional.ofNullable(licencePlate);
         }
 
+        public void setCompany(Company company) {
+            this.company = company;
+        }
+
+        public Optional<Company> getCompany() {
+            return Optional.ofNullable(company);
+        }
+
         public void setPolicyNumber(PolicyNumber policyNumber) {
             this.policyNumber = policyNumber;
         }
@@ -310,6 +335,7 @@ public class EditCommand extends Command {
                     && Objects.equals(tags, otherEditPersonDescriptor.tags)
                     && Objects.equals(nric, otherEditPersonDescriptor.nric)
                     && Objects.equals(licencePlate, otherEditPersonDescriptor.licencePlate)
+                    && Objects.equals(company, otherEditPersonDescriptor.company)
                     && Objects.equals(policyNumber, otherEditPersonDescriptor.policyNumber)
                     && Objects.equals(policyIssueDate, otherEditPersonDescriptor.policyIssueDate)
                     && Objects.equals(policyExpiryDate, otherEditPersonDescriptor.policyExpiryDate);
@@ -317,6 +343,7 @@ public class EditCommand extends Command {
 
         protected String getPolicy() {
             return new ToStringBuilder(this)
+                    .add("company", company)
                     .add("policyNumber", policyNumber)
                     .add("policyIssueDate", policyIssueDate)
                     .add("policyExpiryDate", policyExpiryDate)

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -10,6 +10,7 @@ import seedu.address.commons.util.PredicateUtil;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.CompanyContainsKeywordsPredicate;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.LicenceContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -20,6 +21,7 @@ import seedu.address.model.person.PolicyExpiryContainsKeywordsPredicate;
 import seedu.address.model.person.PolicyIssueContainsKeywordsPredicate;
 import seedu.address.model.person.PolicyNumberContainsKeywordsPredicate;
 import seedu.address.model.person.TagContainsKeywordsPredicate;
+import seedu.address.model.policy.Company;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -35,14 +37,15 @@ public class FindCommand extends Command {
             + "Example: " + COMMAND_WORD + " n/Alice Rodriguez";
 
     private final NameContainsKeywordsPredicate namePredicate;
-    private final LicenceContainsKeywordsPredicate licencePredicate;
-    private final NricContainsKeywordsPredicate nricPredicate;
     private final PhoneContainsKeywordsPredicate phonePredicate;
-    private final PolicyNumberContainsKeywordsPredicate policyNumberPredicate;
-    private final TagContainsKeywordsPredicate tagPredicate;
-    private final PolicyExpiryContainsKeywordsPredicate policyExpiryPredicate;
     private final EmailContainsKeywordsPredicate emailPredicate;
+    private final TagContainsKeywordsPredicate tagPredicate;
+    private final NricContainsKeywordsPredicate nricPredicate;
+    private final LicenceContainsKeywordsPredicate licencePredicate;
+    private final CompanyContainsKeywordsPredicate companyPredicate;
+    private final PolicyNumberContainsKeywordsPredicate policyNumberPredicate;
     private final PolicyIssueContainsKeywordsPredicate policyIssuePredicate;
+    private final PolicyExpiryContainsKeywordsPredicate policyExpiryPredicate;
 
     /**
      * Constructor for FindCommand
@@ -58,7 +61,8 @@ public class FindCommand extends Command {
                        TagContainsKeywordsPredicate tagPredicate,
                        PolicyExpiryContainsKeywordsPredicate policyExpiryPredicate,
                        EmailContainsKeywordsPredicate emailPredicate,
-                       PolicyIssueContainsKeywordsPredicate policyIssuePredicate) {
+                       PolicyIssueContainsKeywordsPredicate policyIssuePredicate,
+                       CompanyContainsKeywordsPredicate companyPredicate) {
         this.namePredicate = namePredicate;
         this.licencePredicate = licencePredicate;
         this.nricPredicate = nricPredicate;
@@ -68,6 +72,7 @@ public class FindCommand extends Command {
         this.policyExpiryPredicate = policyExpiryPredicate;
         this.emailPredicate = emailPredicate;
         this.policyIssuePredicate = policyIssuePredicate;
+        this.companyPredicate = companyPredicate;
     }
 
     @Override
@@ -93,7 +98,15 @@ public class FindCommand extends Command {
 
         FindCommand otherFindCommand = (FindCommand) other;
         return namePredicate.equals(otherFindCommand.namePredicate)
-                && licencePredicate.equals(otherFindCommand.licencePredicate);
+                && phonePredicate.equals(otherFindCommand.phonePredicate)
+                && emailPredicate.equals(otherFindCommand.emailPredicate)
+                && tagPredicate.equals(otherFindCommand.tagPredicate)
+                && nricPredicate.equals(otherFindCommand.nricPredicate)
+                && licencePredicate.equals(otherFindCommand.licencePredicate)
+                && companyPredicate.equals(otherFindCommand.companyPredicate)
+                && policyNumberPredicate.equals(otherFindCommand.policyNumberPredicate)
+                && policyExpiryPredicate.equals(otherFindCommand.policyExpiryPredicate)
+                && policyIssuePredicate.equals(otherFindCommand.policyIssuePredicate);
     }
 
     @Override
@@ -108,6 +121,7 @@ public class FindCommand extends Command {
                 .add("policy expiry predicate", policyExpiryPredicate)
                 .add("email predicate", emailPredicate)
                 .add("policy issue predicate", policyIssuePredicate)
+                .add("company predicate", companyPredicate)
                 .toString();
     }
 
@@ -140,6 +154,9 @@ public class FindCommand extends Command {
         }
         if (!policyIssuePredicate.isEmpty()) {
             predicates.add(policyIssuePredicate);
+        }
+        if (!companyPredicate.isEmpty()) {
+            predicates.add(companyPredicate);
         }
         return predicates;
     }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -21,7 +21,6 @@ import seedu.address.model.person.PolicyExpiryContainsKeywordsPredicate;
 import seedu.address.model.person.PolicyIssueContainsKeywordsPredicate;
 import seedu.address.model.person.PolicyNumberContainsKeywordsPredicate;
 import seedu.address.model.person.TagContainsKeywordsPredicate;
-import seedu.address.model.policy.Company;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.Messages.MESSAGE_MISSING_FIELDS_FOR_ADD_COMMAN
 import static seedu.address.logic.Messages.MESSAGE_MISSING_FIELDS_POLICY_FOR_ADD_COMMAND;
 import static seedu.address.logic.Messages.MESSAGE_PREAMBLE_DETECTED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LICENCE_PLATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -27,6 +28,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.policy.Company;
 import seedu.address.model.policy.Policy;
 import seedu.address.model.policy.PolicyDate;
 import seedu.address.model.policy.PolicyNumber;
@@ -45,8 +47,8 @@ public class AddCommandParser implements Parser<AddCommand> {
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NRIC,
-                        PREFIX_LICENCE_PLATE, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_POLICY_NUMBER,
-                        PREFIX_POLICY_ISSUE_DATE, PREFIX_POLICY_EXPIRY_DATE);
+                        PREFIX_LICENCE_PLATE, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_COMPANY,
+                        PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE, PREFIX_POLICY_EXPIRY_DATE);
 
         if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_PREAMBLE_DETECTED));
@@ -86,11 +88,14 @@ public class AddCommandParser implements Parser<AddCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        if (!arePrefixesAbsent(argMultimap, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
+        if (!arePrefixesAbsent(argMultimap, PREFIX_COMPANY, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
                 PREFIX_POLICY_EXPIRY_DATE)) {
-            if (!arePrefixesPresent(argMultimap, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
+            if (!arePrefixesPresent(argMultimap, PREFIX_COMPANY, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
                     PREFIX_POLICY_EXPIRY_DATE)) {
                 String errorMessage = MESSAGE_MISSING_FIELDS_POLICY_FOR_ADD_COMMAND;
+                if (argMultimap.getValue(PREFIX_COMPANY).isEmpty()) {
+                    errorMessage += "- Company(" + PREFIX_COMPANY + ") ";
+                }
                 if (argMultimap.getValue(PREFIX_POLICY_NUMBER).isEmpty()) {
                     errorMessage += "- Policy Number(" + PREFIX_POLICY_NUMBER + ") ";
                 }
@@ -105,6 +110,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         // temporary variables for when no policy paramers were inputed
+        Company company = new Company(Company.DEFAULT_VALUE);
         PolicyNumber policyNumber = new PolicyNumber(PolicyNumber.DEFAULT_VALUE);
         PolicyDate policyIssueDate = new PolicyDate(PolicyDate.DEFAULT_VALUE);
         PolicyDate policyExpiryDate = new PolicyDate(PolicyDate.DEFAULT_VALUE);
@@ -118,7 +124,7 @@ public class AddCommandParser implements Parser<AddCommand> {
             policyExpiryDate = ParserUtil.parsePolicyExpiryDate(argMultimap.getValue(PREFIX_POLICY_EXPIRY_DATE).get());
         }
 
-        Policy policy = new Policy(policyNumber, policyIssueDate, policyExpiryDate);
+        Policy policy = new Policy(company, policyNumber, policyIssueDate, policyExpiryDate);
 
         Person person = new Person(name, phone, email, address, tagList, nric, licencePlate, policy);
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -116,9 +116,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         PolicyDate policyExpiryDate = new PolicyDate(PolicyDate.DEFAULT_VALUE);
 
         // if all details about policy exists
-        if (arePrefixesPresent(argMultimap, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
+        if (arePrefixesPresent(argMultimap, PREFIX_COMPANY, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
                 PREFIX_POLICY_EXPIRY_DATE)
                 || !argMultimap.getPreamble().isEmpty()) {
+            company = ParserUtil.parseCompany(argMultimap.getValue(PREFIX_COMPANY).get());
             policyNumber = ParserUtil.parsePolicyNumber(argMultimap.getValue(PREFIX_POLICY_NUMBER).get());
             policyIssueDate = ParserUtil.parsePolicyIssueDate(argMultimap.getValue(PREFIX_POLICY_ISSUE_DATE).get());
             policyExpiryDate = ParserUtil.parsePolicyExpiryDate(argMultimap.getValue(PREFIX_POLICY_EXPIRY_DATE).get());

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LICENCE_PLATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -32,6 +33,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
      * and returns an EditCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditCommand parse(String args) throws ParseException {
@@ -46,7 +48,7 @@ public class EditCommandParser implements Parser<EditCommand> {
                         PREFIX_TAG,
                         PREFIX_NRIC,
                         PREFIX_LICENCE_PLATE,
-                        // PREFIX_COMPANY,
+                        PREFIX_COMPANY,
                         PREFIX_POLICY_NUMBER,
                         PREFIX_POLICY_ISSUE_DATE,
                         PREFIX_POLICY_EXPIRY_DATE
@@ -84,10 +86,10 @@ public class EditCommandParser implements Parser<EditCommand> {
                     ParserUtil.parseLicencePlate(argMultimap.getValue(PREFIX_LICENCE_PLATE).get()));
         }
 
-        //        if (argMultimap.getValue(PREFIX_COMPANY).isPresent()) {
-        //            editPersonDescriptor.setCompany(
-        //            ParserUtil.parseCompany(argMultimap.getValue(PREFIX_COMPANY).get()));
-        //        }
+        if (argMultimap.getValue(PREFIX_COMPANY).isPresent()) {
+            editPersonDescriptor.setCompany(
+                    ParserUtil.parseCompany(argMultimap.getValue(PREFIX_COMPANY).get()));
+        }
 
         if (argMultimap.getValue(PREFIX_POLICY_NUMBER).isPresent()) {
             editPersonDescriptor.setPolicyNumber(

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LICENCE_PLATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -13,6 +14,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.CompanyContainsKeywordsPredicate;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.LicenceContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -30,6 +32,7 @@ public class FindCommandParser implements Parser<FindCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
@@ -42,7 +45,8 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TAG,
-                        PREFIX_NRIC, PREFIX_LICENCE_PLATE, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
+                        PREFIX_NRIC, PREFIX_LICENCE_PLATE, PREFIX_COMPANY,
+                        PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
                         PREFIX_POLICY_EXPIRY_DATE);
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TAG,
@@ -58,6 +62,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         String policyExpiryKeyword = "";
         String emailKeyword = "";
         String policyIssueKeyword = "";
+        String companyKeyword = "";
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             nameKeyword = argMultimap.getValue(PREFIX_NAME).get();
@@ -86,6 +91,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(PREFIX_POLICY_ISSUE_DATE).isPresent()) {
             policyIssueKeyword = argMultimap.getValue(PREFIX_POLICY_ISSUE_DATE).get();
         }
+        if (argMultimap.getValue(PREFIX_COMPANY).isPresent()) {
+            companyKeyword = argMultimap.getValue(PREFIX_COMPANY).get();
+        }
 
         return new FindCommand(new NameContainsKeywordsPredicate(nameKeyword),
                 new LicenceContainsKeywordsPredicate(licenceKeyword),
@@ -95,7 +103,8 @@ public class FindCommandParser implements Parser<FindCommand> {
                 new TagContainsKeywordsPredicate(tagKeyword),
                 new PolicyExpiryContainsKeywordsPredicate(policyExpiryKeyword),
                 new EmailContainsKeywordsPredicate(emailKeyword),
-                new PolicyIssueContainsKeywordsPredicate(policyIssueKeyword));
+                new PolicyIssueContainsKeywordsPredicate(policyIssueKeyword),
+                new CompanyContainsKeywordsPredicate(companyKeyword));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -18,6 +18,7 @@ import seedu.address.model.person.LicencePlate;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Phone;
+import seedu.address.model.policy.Company;
 import seedu.address.model.policy.PolicyDate;
 import seedu.address.model.policy.PolicyNumber;
 import seedu.address.model.tag.Tag;
@@ -205,19 +206,18 @@ public class ParserUtil {
         return new PolicyDate(trimmedPolicyExpiryDate);
     }
 
-    //    /**
-    //     * Parses a {@code String company} into an {@code Company}.
-    //     * Leading and trailing whitespaces will be trimmed.
-    //     *
-    //     * @throws ParseException if the given {@code company} is invalid.
-    //     */
-    //    public static Company parseCompany(String company) throws ParseException {
-    //        requireNonNull(company);
-    //        String trimmedCompany = company.trim();
-    //        if (!Company.isValidCompany(trimmedCompany)) {
-    //            throw new ParseException(Company.MESSAGE_CONSTRAINTS);
-    //        }
-    //        return new Company(trimmedCompany);
-    //    }
-
+    /**
+     * Parses a {@code String company} into an {@code Company}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code company} is invalid.
+     */
+    public static Company parseCompany(String company) throws ParseException {
+        requireNonNull(company);
+        String trimmedCompany = company.trim();
+        if (!Company.isValidCompany(trimmedCompany)) {
+            throw new ParseException(Company.MESSAGE_CONSTRAINTS);
+        }
+        return new Company(trimmedCompany);
+    }
 }

--- a/src/main/java/seedu/address/model/person/CompanyContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/CompanyContainsKeywordsPredicate.java
@@ -1,0 +1,37 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Company} matches any of the keywords given.
+ */
+public class CompanyContainsKeywordsPredicate extends FieldPredicates {
+    public CompanyContainsKeywordsPredicate(String keyword) {
+        super(keyword);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword ->
+                        StringUtil.containsWordIgnoreCase(person.getPolicy().getCompany().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CompanyContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        CompanyContainsKeywordsPredicate otherNameContainsKeywordsPredicate =
+                (CompanyContainsKeywordsPredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+    }
+}
+
+}

--- a/src/main/java/seedu/address/model/person/CompanyContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/CompanyContainsKeywordsPredicate.java
@@ -33,5 +33,3 @@ public class CompanyContainsKeywordsPredicate extends FieldPredicates {
         return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
     }
 }
-
-}

--- a/src/main/java/seedu/address/model/policy/Company.java
+++ b/src/main/java/seedu/address/model/policy/Company.java
@@ -3,6 +3,10 @@ package seedu.address.model.policy;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+/**
+ * Represents a car insurance company in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidCompany(String)}
+ */
 public class Company {
 
     public static final String MESSAGE_CONSTRAINTS = "Should not contain unrecognizable characters";

--- a/src/main/java/seedu/address/model/policy/Company.java
+++ b/src/main/java/seedu/address/model/policy/Company.java
@@ -1,0 +1,61 @@
+package seedu.address.model.policy;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+public class Company {
+
+    public static final String MESSAGE_CONSTRAINTS = "Should not contain unrecognizable characters";
+
+    /*
+     * Company name can be anything understandable to human being.
+     */
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9.]+$";
+    public static final String DEFAULT_VALUE = "NOCOMPANY";
+
+    public final String value;
+
+    /**
+     * Constructs a {@code Company}.
+     *
+     * @param company A valid policy number.
+     */
+    public Company(String company) {
+        requireNonNull(company);
+        checkArgument(isValidCompany(company), MESSAGE_CONSTRAINTS);
+        value = company;
+    }
+
+    /**
+     * Returns true if a given string is a valid company.
+     */
+    public static boolean isValidCompany(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Company)) {
+            return false;
+        }
+
+        Company otherCompany = (Company) other;
+        return value.equals(otherCompany.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/policy/Company.java
+++ b/src/main/java/seedu/address/model/policy/Company.java
@@ -18,7 +18,7 @@ public class Company {
     /**
      * Constructs a {@code Company}.
      *
-     * @param company A valid policy number.
+     * @param company A valid company.
      */
     public Company(String company) {
         requireNonNull(company);
@@ -57,5 +57,4 @@ public class Company {
     public int hashCode() {
         return value.hashCode();
     }
-
 }

--- a/src/main/java/seedu/address/model/policy/Policy.java
+++ b/src/main/java/seedu/address/model/policy/Policy.java
@@ -9,6 +9,7 @@ import seedu.address.commons.util.ToStringBuilder;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Policy {
+    private final Company company;
 
     private final PolicyNumber policyNumber;
     private final PolicyDate policyIssueDate;
@@ -18,12 +19,16 @@ public class Policy {
      * Every field must be present and not null.
      * In the case of leads with null policy fields, default values will be put in place by the respective classes.
      */
-    public Policy(PolicyNumber policyNumber, PolicyDate policyIssueDate, PolicyDate policyExpiryDate) {
+    public Policy(Company company, PolicyNumber policyNumber, PolicyDate policyIssueDate, PolicyDate policyExpiryDate) {
+        this.company = company;
         this.policyNumber = policyNumber;
         this.policyIssueDate = policyIssueDate;
         this.policyExpiryDate = policyExpiryDate;
     }
 
+    public Company getCompany() {
+        return company;
+    }
     public PolicyNumber getPolicyNumber() {
         return policyNumber;
     }
@@ -48,19 +53,21 @@ public class Policy {
         }
 
         Policy otherPolicy = (Policy) other;
-        return policyNumber.equals(otherPolicy.policyNumber)
+        return company.equals(otherPolicy.company)
+                && policyNumber.equals(otherPolicy.policyNumber)
                 && policyIssueDate.equals(otherPolicy.policyIssueDate)
                 && policyExpiryDate.equals(otherPolicy.policyExpiryDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(policyNumber, policyIssueDate, policyExpiryDate);
+        return Objects.hash(company, policyNumber, policyIssueDate, policyExpiryDate);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
+                .add("company", company)
                 .add("policy number", policyNumber)
                 .add("policy issue date", policyIssueDate)
                 .add("policy expiry date", policyExpiryDate)
@@ -75,14 +82,14 @@ public class Policy {
      * @return the string representation of the Policy.
      */
     public String toDisplay(boolean isPersonCard) {
-        if (policyNumber.value.equals(PolicyNumber.DEFAULT_VALUE)) {
+        if (policyNumber.toString().equals(PolicyNumber.DEFAULT_VALUE)) {
             // Policy does not actually exist
             return "No Policy Found";
         }
 
         if (isPersonCard) {
-            return policyNumber.value + "\n" + policyIssueDate.toString() + "\n" + policyExpiryDate.toString();
+            return company + "\n" + policyNumber + "\n" + policyIssueDate + "\n" + policyExpiryDate;
         }
-        return policyNumber.value + ", " + policyIssueDate.toString() + ", " + policyExpiryDate.toString();
+        return company + ", " + policyNumber + ", " + policyIssueDate + ", " + policyExpiryDate;
     }
 }

--- a/src/main/java/seedu/address/model/policy/Policy.java
+++ b/src/main/java/seedu/address/model/policy/Policy.java
@@ -10,7 +10,6 @@ import seedu.address.commons.util.ToStringBuilder;
  */
 public class Policy {
     private final Company company;
-
     private final PolicyNumber policyNumber;
     private final PolicyDate policyIssueDate;
     private final PolicyDate policyExpiryDate;

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -13,6 +13,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.policy.Company;
 import seedu.address.model.policy.Policy;
 import seedu.address.model.policy.PolicyDate;
 import seedu.address.model.policy.PolicyNumber;
@@ -27,29 +28,29 @@ public class SampleDataUtil {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
                 getTagSet("friends"), new Nric("023A"), new LicencePlate("SNB9538E"),
-                new Policy(new PolicyNumber("A1231X"), new PolicyDate("01-01-2023"), new PolicyDate("01-01-2024"))),
+                new Policy(new Company("NTUC"), new PolicyNumber("A1231X"), new PolicyDate("01-01-2023"), new PolicyDate("01-01-2024"))),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                 getTagSet("colleagues", "friends"), new Nric("362D"), new LicencePlate("SLR5E"),
-                new Policy(new PolicyNumber("B3425"), new PolicyDate("01-01-2020"), new PolicyDate("01-01-2030"))),
+                new Policy(new Company("InsureMe"), new PolicyNumber("B3425"), new PolicyDate("01-01-2020"), new PolicyDate("01-01-2030"))),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
                 getTagSet("neighbours"), new Nric("743G"), new LicencePlate("SBA1234A"),
-                new Policy(new PolicyNumber("B3425"), new PolicyDate("20-12-2020"), new PolicyDate("01-01-2030"))),
+                new Policy(new Company("NTUC"), new PolicyNumber("B3425"), new PolicyDate("20-12-2020"), new PolicyDate("01-01-2030"))),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
                 getTagSet("family"), new Nric("362D"), new LicencePlate("SDN5345A"),
-                    new Policy(new PolicyNumber(PolicyNumber.DEFAULT_VALUE),
+                    new Policy(new Company("NTUC"), new PolicyNumber(PolicyNumber.DEFAULT_VALUE),
                             new PolicyDate(PolicyDate.DEFAULT_VALUE), new PolicyDate(PolicyDate.DEFAULT_VALUE))),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
                 getTagSet("classmates"), new Nric("752X"), new LicencePlate("SBP8888T"),
-                    new Policy(new PolicyNumber(PolicyNumber.DEFAULT_VALUE),
+                    new Policy(new Company("InsureMe"), new PolicyNumber(PolicyNumber.DEFAULT_VALUE),
                             new PolicyDate(PolicyDate.DEFAULT_VALUE), new PolicyDate(PolicyDate.DEFAULT_VALUE))),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
                 getTagSet("colleagues"), new Nric("764J"), new LicencePlate("SJD6453Y"),
-                    new Policy(new PolicyNumber(PolicyNumber.DEFAULT_VALUE),
+                    new Policy(new Company("InsureMe"), new PolicyNumber(PolicyNumber.DEFAULT_VALUE),
                             new PolicyDate(PolicyDate.DEFAULT_VALUE), new PolicyDate(PolicyDate.DEFAULT_VALUE)))
         };
     }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -24,34 +24,97 @@ import seedu.address.model.tag.Tag;
  */
 public class SampleDataUtil {
     public static Person[] getSamplePersons() {
-        return new Person[] {
-            new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
+        return new Person[]{
+            new Person(
+                new Name("Alex Yeoh"),
+                new Phone("87438807"),
+                new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends"), new Nric("023A"), new LicencePlate("SNB9538E"),
-                new Policy(new Company("NTUC"), new PolicyNumber("A1231X"), new PolicyDate("01-01-2023"), new PolicyDate("01-01-2024"))),
-            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
+                getTagSet("friends"),
+                new Nric("023A"),
+                new LicencePlate("SNB9538E"),
+                new Policy(
+                    new Company("NTUC"),
+                    new PolicyNumber("A1231X"),
+                    new PolicyDate("01-01-2023"),
+                    new PolicyDate("01-01-2024")
+                )
+            ),
+            new Person(
+                new Name("Bernice Yu"),
+                new Phone("99272758"),
+                new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends"), new Nric("362D"), new LicencePlate("SLR5E"),
-                new Policy(new Company("InsureMe"), new PolicyNumber("B3425"), new PolicyDate("01-01-2020"), new PolicyDate("01-01-2030"))),
-            new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
+                getTagSet("colleagues", "friends"),
+                new Nric("362D"),
+                new LicencePlate("SLR5E"),
+                new Policy(
+                    new Company("InsureMe"),
+                    new PolicyNumber("B3425"),
+                    new PolicyDate("01-01-2020"),
+                    new PolicyDate("01-01-2030")
+                )
+            ),
+            new Person(
+                new Name("Charlotte Oliveiro"),
+                new Phone("93210283"),
+                new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours"), new Nric("743G"), new LicencePlate("SBA1234A"),
-                new Policy(new Company("NTUC"), new PolicyNumber("B3425"), new PolicyDate("20-12-2020"), new PolicyDate("01-01-2030"))),
-            new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
+                getTagSet("neighbours"),
+                new Nric("743G"),
+                new LicencePlate("SBA1234A"),
+                new Policy(
+                    new Company("NTUC"),
+                    new PolicyNumber("B3425"),
+                    new PolicyDate("20-12-2020"),
+                    new PolicyDate("01-01-2030")
+                )
+            ),
+            new Person(
+                new Name("David Li"),
+                new Phone("91031282"),
+                new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family"), new Nric("362D"), new LicencePlate("SDN5345A"),
-                    new Policy(new Company("NTUC"), new PolicyNumber(PolicyNumber.DEFAULT_VALUE),
-                            new PolicyDate(PolicyDate.DEFAULT_VALUE), new PolicyDate(PolicyDate.DEFAULT_VALUE))),
-            new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
+                getTagSet("family"),
+                new Nric("362D"),
+                new LicencePlate("SDN5345A"),
+                new Policy(
+                    new Company("NTUC"),
+                    new PolicyNumber(PolicyNumber.DEFAULT_VALUE),
+                    new PolicyDate(PolicyDate.DEFAULT_VALUE),
+                    new PolicyDate(PolicyDate.DEFAULT_VALUE)
+                )
+            ),
+            new Person(
+                new Name("Irfan Ibrahim"),
+                new Phone("92492021"),
+                new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates"), new Nric("752X"), new LicencePlate("SBP8888T"),
-                    new Policy(new Company("InsureMe"), new PolicyNumber(PolicyNumber.DEFAULT_VALUE),
-                            new PolicyDate(PolicyDate.DEFAULT_VALUE), new PolicyDate(PolicyDate.DEFAULT_VALUE))),
-            new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
+                getTagSet("classmates"),
+                new Nric("752X"),
+                new LicencePlate("SBP8888T"),
+                new Policy(
+                    new Company("InsureMe"),
+                    new PolicyNumber(PolicyNumber.DEFAULT_VALUE),
+                    new PolicyDate(PolicyDate.DEFAULT_VALUE),
+                    new PolicyDate(PolicyDate.DEFAULT_VALUE)
+                )
+            ),
+            new Person(
+                new Name("Roy Balakrishnan"),
+                new Phone("92624417"),
+                new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"), new Nric("764J"), new LicencePlate("SJD6453Y"),
-                    new Policy(new Company("InsureMe"), new PolicyNumber(PolicyNumber.DEFAULT_VALUE),
-                            new PolicyDate(PolicyDate.DEFAULT_VALUE), new PolicyDate(PolicyDate.DEFAULT_VALUE)))
+                getTagSet("colleagues"),
+                new Nric("764J"),
+                new LicencePlate("SJD6453Y"),
+                new Policy(
+                    new Company("InsureMe"),
+                    new PolicyNumber(PolicyNumber.DEFAULT_VALUE),
+                    new PolicyDate(PolicyDate.DEFAULT_VALUE),
+                    new PolicyDate(PolicyDate.DEFAULT_VALUE)
+                )
+            )
         };
     }
 
@@ -68,8 +131,8 @@ public class SampleDataUtil {
      */
     public static Set<Tag> getTagSet(String... strings) {
         return Arrays.stream(strings)
-                .map(Tag::new)
-                .collect(Collectors.toSet());
+            .map(Tag::new)
+            .collect(Collectors.toSet());
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -188,7 +188,13 @@ class JsonAdaptedPerson {
         }
         final PolicyDate modelPolicyExpiryDate = new PolicyDate(policyExpiryDate);
 
-        final Policy modelPolicy = new Policy(modelCompany,modelPolicyNumber, modelPolicyIssueDate, modelPolicyExpiryDate);
+        final Policy modelPolicy = new Policy(
+                modelCompany,
+                modelPolicyNumber,
+                modelPolicyIssueDate,
+                modelPolicyExpiryDate
+        );
+
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags,
                 modelNric, modelLicencePlate, modelPolicy);
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -17,6 +17,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.policy.Company;
 import seedu.address.model.policy.Policy;
 import seedu.address.model.policy.PolicyDate;
 import seedu.address.model.policy.PolicyNumber;
@@ -36,6 +37,7 @@ class JsonAdaptedPerson {
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
     private final String nric;
     private final String licencePlate;
+    private final String company;
     private final String policyNumber;
     private final String policyIssueDate;
     private final String policyExpiryDate;
@@ -47,7 +49,8 @@ class JsonAdaptedPerson {
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
             @JsonProperty("tags") List<JsonAdaptedTag> tags, @JsonProperty("nric") String nric,
-            @JsonProperty("licencePlate") String licencePlate, @JsonProperty("policyNumber") String policyNumber,
+            @JsonProperty("licencePlate") String licencePlate, @JsonProperty("company") String company,
+            @JsonProperty("policyNumber") String policyNumber,
             @JsonProperty("policyIssueDate") String policyIssueDate,
             @JsonProperty("policyExpiryDate") String policyExpiryDate) {
         this.name = name;
@@ -59,6 +62,7 @@ class JsonAdaptedPerson {
         }
         this.nric = nric;
         this.licencePlate = licencePlate;
+        this.company = company;
         this.policyNumber = policyNumber;
         this.policyIssueDate = policyIssueDate;
         this.policyExpiryDate = policyExpiryDate;
@@ -78,6 +82,7 @@ class JsonAdaptedPerson {
         nric = source.getNric().value;
         licencePlate = source.getLicencePlate().value;
         Policy sourcePolicy = source.getPolicy();
+        company = sourcePolicy.getCompany().value;
         policyNumber = sourcePolicy.getPolicyNumber().value;
         policyIssueDate = sourcePolicy.getPolicyIssueDate().toString();
         policyExpiryDate = sourcePolicy.getPolicyExpiryDate().toString();
@@ -147,6 +152,15 @@ class JsonAdaptedPerson {
         final LicencePlate modelLicencePlate = new LicencePlate(licencePlate);
 
         // Policy fields
+        if (company == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Company.class.getSimpleName()));
+        }
+        if (!Company.isValidCompany(company)) {
+            throw new IllegalValueException(Company.MESSAGE_CONSTRAINTS);
+        }
+        final Company modelCompany = new Company(company);
+
         if (policyNumber == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     PolicyNumber.class.getSimpleName()));
@@ -174,7 +188,7 @@ class JsonAdaptedPerson {
         }
         final PolicyDate modelPolicyExpiryDate = new PolicyDate(policyExpiryDate);
 
-        final Policy modelPolicy = new Policy(modelPolicyNumber, modelPolicyIssueDate, modelPolicyExpiryDate);
+        final Policy modelPolicy = new Policy(modelCompany,modelPolicyNumber, modelPolicyIssueDate, modelPolicyExpiryDate);
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags,
                 modelNric, modelLicencePlate, modelPolicy);
     }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -7,6 +7,7 @@
     "tags": [ "friends" ],
     "nric" : "362D",
     "licencePlate" : "SLR5E",
+    "company" : "NTUC",
     "policyNumber" : "B3425",
     "policyIssueDate" : "01-01-2020",
     "policyExpiryDate" : "01-01-2030"
@@ -17,6 +18,7 @@
     "address": "4th street",
     "nric" : "362D",
     "licencePlate" : "SLR5E",
+    "company" : "NTUC",
     "policyNumber" : "B3425",
     "policyIssueDate" : "01-01-2020",
     "policyExpiryDate" : "01-01-2030"

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -6,6 +6,7 @@
     "address": "4th street",
     "nric" : "362D",
     "licencePlate" : "SLR5E",
+    "company" : "☺",
     "policyNumber" : "B3425",
     "policyIssueDate" : "01-01-2020",
     "policyExpiryDate" : "01-01-2030"

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -8,6 +8,7 @@
     "tags" : [ "friends" ],
     "nric" : "000A",
     "licencePlate" : "SBA1234A",
+    "company" : "NTUC",
     "policyNumber" : "AIA1",
     "policyIssueDate" : "01-01-2020",
     "policyExpiryDate" : "01-02-2020"
@@ -19,6 +20,7 @@
     "tags" : [ "owesMoney", "friends" ],
     "nric" : "001B",
     "licencePlate" : "SBA5555B",
+    "company" : "InsureMe",
     "policyNumber" : "AIA2",
     "policyIssueDate" : "12-12-2010",
     "policyExpiryDate" : "12-12-2020"
@@ -30,6 +32,7 @@
     "tags" : [ ],
     "nric" : "123C",
     "licencePlate" : "SLR8E",
+    "company" : "InsureMe",
     "policyNumber" : "5734534X",
     "policyIssueDate" : "31-12-2019",
     "policyExpiryDate" : "01-01-2020"
@@ -41,7 +44,8 @@
     "tags" : [ "friends" ],
     "nric" : "464J",
     "licencePlate" : "STG46P",
-    "policyNumber" : "NTUC4532",
+    "company" : "NTUC",
+    "policyNumber" : "4532",
     "policyIssueDate" : "29-02-2004",
     "policyExpiryDate" : "29-02-2008"
   }, {
@@ -52,6 +56,7 @@
     "tags" : [ ],
     "nric" : "573H",
     "licencePlate" : "SHL463C",
+    "company" : "NTUC",
     "policyNumber" : "NOPOLICY",
     "policyIssueDate" : "01-01-1000",
     "policyExpiryDate" : "01-01-1000"
@@ -63,6 +68,7 @@
     "tags" : [ ],
     "nric" : "743G",
     "licencePlate" : "SBA1Z",
+    "company" : "InsureMe",
     "policyNumber" : "NOPOLICY",
     "policyIssueDate" : "01-01-1000",
     "policyExpiryDate" : "01-01-1000"
@@ -74,6 +80,7 @@
     "tags" : [ ],
     "nric" : "674G",
     "licencePlate" : "SNM9735R",
+    "company" : "InsureMe",
     "policyNumber" : "NOPOLICY",
     "policyIssueDate" : "01-01-1000",
     "policyExpiryDate" : "01-01-1000"

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LICENCE_PLATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -44,6 +45,8 @@ public class CommandTestUtil {
     public static final String VALID_NRIC_BOB = "123Z";
     public static final String VALID_LICENCE_PLATE_AMY = "SBC123D";
     public static final String VALID_LICENCE_PLATE_BOB = "SYZ4321Z";
+    public static final String VALID_COMPANY_AMY = "NTUC";
+    public static final String VALID_COMPANY_BOB = "InsureMe";
     public static final String VALID_POLICY_NO_AMY = "AIA1234";
     public static final String VALID_POLICY_NO_BOB = "BBBB2";
     public static final String VALID_POLICY_ISSUE_DATE_AMY = "01-01-2023";
@@ -66,6 +69,8 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String COMPANY_DESC_AMY = " " + PREFIX_COMPANY + VALID_COMPANY_AMY;
+    public static final String COMPANY_DESC_BOB = " " + PREFIX_COMPANY + VALID_COMPANY_BOB;
     public static final String POLICY_NO_DESC_AMY = " " + PREFIX_POLICY_NUMBER + VALID_POLICY_NO_AMY;
     public static final String POLICY_NO_DESC_BOB = " " + PREFIX_POLICY_NUMBER + VALID_POLICY_NO_BOB;
     public static final String POLICY_ISSUE_DATE_DESC_AMY = " " + PREFIX_POLICY_ISSUE_DATE

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.CompanyContainsKeywordsPredicate;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.LicenceContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -69,14 +70,20 @@ public class FindCommandTest {
                 new PolicyIssueContainsKeywordsPredicate("12-12-2022");
         PolicyIssueContainsKeywordsPredicate secondPolicyIssuePredicate =
                 new PolicyIssueContainsKeywordsPredicate("11-11-2022");
+        CompanyContainsKeywordsPredicate firstCompanyPredicate =
+                new CompanyContainsKeywordsPredicate("NTUC");
+        CompanyContainsKeywordsPredicate secondCompanyPredicate =
+                new CompanyContainsKeywordsPredicate("InsureMe");
 
 
         FindCommand findFirstCommand = new FindCommand(firstNamePredicate, firstLicencePredicate,
                 firstNricPredicate, firstPhonePredicate, firstPolicyNumPredicate, firstTagPredicate,
-                firstPolicyExpiryPredicate, firstEmailPredicate, firstPolicyIssuePredicate);
+                firstPolicyExpiryPredicate, firstEmailPredicate, firstPolicyIssuePredicate,
+                firstCompanyPredicate);
         FindCommand findSecondCommand = new FindCommand(secondNamePredicate, secondLicencePredicate,
                 secondNricPredicate, secondPhonePredicate, secondPolicyNumPredicate, secondTagPredicate,
-                secondPolicyExpiryPredicate, secondEmailPredicate, secondPolicyIssuePredicate);
+                secondPolicyExpiryPredicate, secondEmailPredicate, secondPolicyIssuePredicate,
+                secondCompanyPredicate);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
@@ -84,7 +91,8 @@ public class FindCommandTest {
         // same values -> returns true
         FindCommand findFirstCommandCopy = new FindCommand(firstNamePredicate, firstLicencePredicate,
                 firstNricPredicate, firstPhonePredicate, firstPolicyNumPredicate, firstTagPredicate,
-                firstPolicyExpiryPredicate, firstEmailPredicate, firstPolicyIssuePredicate);
+                firstPolicyExpiryPredicate, firstEmailPredicate, firstPolicyIssuePredicate,
+                firstCompanyPredicate);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -117,8 +125,11 @@ public class FindCommandTest {
                 new EmailContainsKeywordsPredicate("weewooowaa@example.com");
         PolicyIssueContainsKeywordsPredicate policyIssuePredicate =
                 new PolicyIssueContainsKeywordsPredicate("12-12-2022");
+        CompanyContainsKeywordsPredicate companyPredicate =
+                new CompanyContainsKeywordsPredicate("NTUC");
         FindCommand command = new FindCommand(predicate, licencePredicate, nricPredicate, phonePredicate,
-                policyNumPredicate, tagPredicate, policyExpiryPredicate, emailPredicate, policyIssuePredicate);
+                policyNumPredicate, tagPredicate, policyExpiryPredicate, emailPredicate, policyIssuePredicate,
+                companyPredicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
@@ -143,13 +154,17 @@ public class FindCommandTest {
                 new EmailContainsKeywordsPredicate("weewooowaa@example.com");
         PolicyIssueContainsKeywordsPredicate policyIssuePredicate =
                 new PolicyIssueContainsKeywordsPredicate("12-12-2022");
+        CompanyContainsKeywordsPredicate companyPredicate =
+                new CompanyContainsKeywordsPredicate("NTUC");
         FindCommand findCommand = new FindCommand(predicate, licencePredicate, nricPredicate, phonePredicate,
-                policyNumPredicate, tagPredicate, policyExpiryPredicate, emailPredicate, policyIssuePredicate);
+                policyNumPredicate, tagPredicate, policyExpiryPredicate, emailPredicate, policyIssuePredicate,
+                companyPredicate);
         String expected = FindCommand.class.getCanonicalName() + "{name predicate=" + predicate
                 + ", licence predicate=" + licencePredicate + ", nric predicate=" + nricPredicate
                 + ", phone predicate=" + phonePredicate + ", policy number predicate=" + policyNumPredicate
                 + ", tag predicate=" + tagPredicate + ", policy expiry predicate=" + policyExpiryPredicate
-                + ", email predicate=" + emailPredicate + ", policy issue predicate=" + policyIssuePredicate + "}";
+                + ", email predicate=" + emailPredicate + ", policy issue predicate=" + policyIssuePredicate
+                + ", company predicate=" + companyPredicate +"}";
         assertEquals(expected, findCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -164,7 +164,7 @@ public class FindCommandTest {
                 + ", phone predicate=" + phonePredicate + ", policy number predicate=" + policyNumPredicate
                 + ", tag predicate=" + tagPredicate + ", policy expiry predicate=" + policyExpiryPredicate
                 + ", email predicate=" + emailPredicate + ", policy issue predicate=" + policyIssuePredicate
-                + ", company predicate=" + companyPredicate +"}";
+                + ", company predicate=" + companyPredicate + "}";
         assertEquals(expected, findCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -6,6 +6,8 @@ import static seedu.address.logic.Messages.MESSAGE_MISSING_FIELDS_POLICY_FOR_ADD
 import static seedu.address.logic.Messages.MESSAGE_PREAMBLE_DETECTED;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.COMPANY_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.COMPANY_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
@@ -65,7 +67,8 @@ public class AddCommandParserTest {
         // whitespace only preamble
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + NRIC_DESC_BOB + LICENSE_PLATE_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_FRIEND + POLICY_NO_DESC_BOB + POLICY_ISSUE_DATE_DESC_BOB
+                + TAG_DESC_FRIEND + COMPANY_DESC_BOB + POLICY_NO_DESC_BOB
+                + POLICY_ISSUE_DATE_DESC_BOB
                 + POLICY_EXPIRY_DATE_DESC_BOB, new AddCommand(expectedPerson));
 
         // multiple tags - all accepted
@@ -75,7 +78,8 @@ public class AddCommandParserTest {
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + NRIC_DESC_BOB
                         + LICENSE_PLATE_DESC_BOB + ADDRESS_DESC_BOB
                         + TAG_DESC_HUSBAND + TAG_DESC_FRIEND
-                        + POLICY_NO_DESC_BOB + POLICY_ISSUE_DATE_DESC_BOB + POLICY_EXPIRY_DATE_DESC_BOB,
+                        + COMPANY_DESC_BOB + POLICY_NO_DESC_BOB + POLICY_ISSUE_DATE_DESC_BOB
+                        + POLICY_EXPIRY_DATE_DESC_BOB,
                 new AddCommand(expectedPersonMultipleTags));
     }
 
@@ -149,7 +153,7 @@ public class AddCommandParserTest {
         // zero tags
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-                        + NRIC_DESC_AMY + LICENSE_PLATE_DESC_AMY + ADDRESS_DESC_AMY
+                        + NRIC_DESC_AMY + LICENSE_PLATE_DESC_AMY + ADDRESS_DESC_AMY + COMPANY_DESC_AMY
                         + POLICY_NO_DESC_AMY + POLICY_ISSUE_DATE_DESC_AMY + POLICY_EXPIRY_DATE_DESC_AMY,
                 new AddCommand(expectedPerson));
     }
@@ -161,7 +165,8 @@ public class AddCommandParserTest {
         assertParseFailure(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                         + NRIC_DESC_BOB + LICENSE_PLATE_DESC_BOB + ADDRESS_DESC_BOB
-                        + TAG_DESC_FRIEND + POLICY_NO_DESC_BOB + POLICY_ISSUE_DATE_DESC_BOB,
+                        + TAG_DESC_FRIEND + COMPANY_DESC_BOB
+                        + POLICY_NO_DESC_BOB + POLICY_ISSUE_DATE_DESC_BOB,
                 expectedMessage);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.CompanyContainsKeywordsPredicate;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.LicenceContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -78,12 +79,20 @@ public class AddressBookParserTest {
         String keywords = "foo bar fun";
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " n/" + keywords);
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords),
+        assertEquals(
+                new FindCommand(
+                new NameContainsKeywordsPredicate(keywords),
                 new LicenceContainsKeywordsPredicate(""),
                 new NricContainsKeywordsPredicate(""),
-                new PhoneContainsKeywordsPredicate(""), new PolicyNumberContainsKeywordsPredicate(""),
-                new TagContainsKeywordsPredicate(""), new PolicyExpiryContainsKeywordsPredicate(""),
-                new EmailContainsKeywordsPredicate(""), new PolicyIssueContainsKeywordsPredicate("")), command);
+                new PhoneContainsKeywordsPredicate(""),
+                new PolicyNumberContainsKeywordsPredicate(""),
+                new TagContainsKeywordsPredicate(""),
+                new PolicyExpiryContainsKeywordsPredicate(""),
+                new EmailContainsKeywordsPredicate(""),
+                new PolicyIssueContainsKeywordsPredicate(""),
+                new CompanyContainsKeywordsPredicate("")),
+                command
+        );
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.person.CompanyContainsKeywordsPredicate;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.LicenceContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -34,7 +35,8 @@ public class FindCommandParserTest {
                         new LicenceContainsKeywordsPredicate(""), new NricContainsKeywordsPredicate(""),
                         new PhoneContainsKeywordsPredicate(""), new PolicyNumberContainsKeywordsPredicate(""),
                         new TagContainsKeywordsPredicate(""), new PolicyExpiryContainsKeywordsPredicate(""),
-                        new EmailContainsKeywordsPredicate(""), new PolicyIssueContainsKeywordsPredicate(""));
+                        new EmailContainsKeywordsPredicate(""), new PolicyIssueContainsKeywordsPredicate(""),
+                        new CompanyContainsKeywordsPredicate(""));
         assertParseSuccess(parser, "find n/Alice Bob", expectedFindCommand);
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -96,7 +96,8 @@ public class PersonTest {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags()
                 + ", nric=" + ALICE.getNric() + ", licence plate=" + ALICE.getLicencePlate() + ", policy="
-                + Policy.class.getCanonicalName() + "{policy number=" + ALICE.getPolicy().getPolicyNumber()
+                + Policy.class.getCanonicalName() + "{company=" + ALICE.getPolicy().getCompany()
+                + ", policy number=" + ALICE.getPolicy().getPolicyNumber()
                 + ", policy issue date=" + ALICE.getPolicy().getPolicyIssueDate() + ", policy expiry date="
                 + ALICE.getPolicy().getPolicyExpiryDate() + "}}";
         assertEquals(expected, ALICE.toString());

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -33,10 +33,11 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
-            .map(JsonAdaptedTag::new)
-            .collect(Collectors.toList());
+        .map(JsonAdaptedTag::new)
+        .collect(Collectors.toList());
     private static final String VALID_NRIC = "567A";
     private static final String VALID_LICENCE_PLATE = "SBC123D";
+    private static final String VALID_COMPANY = "NTUC";
     private static final String VALID_POLICY_NUMBER = "AIA1234";
     private static final String VALID_POLICY_DATE = "01-01-2023";
 
@@ -49,16 +50,38 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                        VALID_NRIC, VALID_LICENCE_PLATE, VALID_POLICY_NUMBER, VALID_POLICY_DATE, VALID_POLICY_DATE);
+            new JsonAdaptedPerson(
+                INVALID_NAME,
+                VALID_PHONE,
+                VALID_EMAIL,
+                VALID_ADDRESS,
+                VALID_TAGS,
+                VALID_NRIC,
+                VALID_LICENCE_PLATE,
+                VALID_COMPANY,
+                VALID_POLICY_NUMBER,
+                VALID_POLICY_DATE,
+                VALID_POLICY_DATE
+            );
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                VALID_NRIC, VALID_LICENCE_PLATE, VALID_POLICY_NUMBER, VALID_POLICY_DATE, VALID_POLICY_DATE);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+            null,
+            VALID_PHONE,
+            VALID_EMAIL,
+            VALID_ADDRESS,
+            VALID_TAGS,
+            VALID_NRIC,
+            VALID_LICENCE_PLATE,
+            VALID_COMPANY,
+            VALID_POLICY_NUMBER,
+            VALID_POLICY_DATE,
+            VALID_POLICY_DATE
+        );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -66,16 +89,38 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                        VALID_NRIC, VALID_LICENCE_PLATE, VALID_POLICY_NUMBER, VALID_POLICY_DATE, VALID_POLICY_DATE);
+            new JsonAdaptedPerson(
+                VALID_NAME,
+                INVALID_PHONE,
+                VALID_EMAIL,
+                VALID_ADDRESS,
+                VALID_TAGS,
+                VALID_NRIC,
+                VALID_LICENCE_PLATE,
+                VALID_COMPANY,
+                VALID_POLICY_NUMBER,
+                VALID_POLICY_DATE,
+                VALID_POLICY_DATE
+            );
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                VALID_NRIC, VALID_LICENCE_PLATE, VALID_POLICY_NUMBER, VALID_POLICY_DATE, VALID_POLICY_DATE);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+            VALID_NAME,
+            null,
+            VALID_EMAIL,
+            VALID_ADDRESS,
+            VALID_TAGS,
+            VALID_NRIC,
+            VALID_LICENCE_PLATE,
+            VALID_COMPANY,
+            VALID_POLICY_NUMBER,
+            VALID_POLICY_DATE,
+            VALID_POLICY_DATE
+        );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -83,16 +128,38 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                        VALID_NRIC, VALID_LICENCE_PLATE, VALID_POLICY_NUMBER, VALID_POLICY_DATE, VALID_POLICY_DATE);
+            new JsonAdaptedPerson(
+                VALID_NAME,
+                VALID_PHONE,
+                INVALID_EMAIL,
+                VALID_ADDRESS,
+                VALID_TAGS,
+                VALID_NRIC,
+                VALID_LICENCE_PLATE,
+                VALID_COMPANY,
+                VALID_POLICY_NUMBER,
+                VALID_POLICY_DATE,
+                VALID_POLICY_DATE
+            );
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS,
-                VALID_NRIC, VALID_LICENCE_PLATE, VALID_POLICY_NUMBER, VALID_POLICY_DATE, VALID_POLICY_DATE);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+            VALID_NAME,
+            VALID_PHONE,
+            null,
+            VALID_ADDRESS,
+            VALID_TAGS,
+            VALID_NRIC,
+            VALID_LICENCE_PLATE,
+            VALID_COMPANY,
+            VALID_POLICY_NUMBER,
+            VALID_POLICY_DATE,
+            VALID_POLICY_DATE
+        );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -100,16 +167,38 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS,
-                        VALID_NRIC, VALID_LICENCE_PLATE, VALID_POLICY_NUMBER, VALID_POLICY_DATE, VALID_POLICY_DATE);
+            new JsonAdaptedPerson(
+                VALID_NAME,
+                VALID_PHONE,
+                VALID_EMAIL,
+                INVALID_ADDRESS,
+                VALID_TAGS,
+                VALID_NRIC,
+                VALID_LICENCE_PLATE,
+                VALID_COMPANY,
+                VALID_POLICY_NUMBER,
+                VALID_POLICY_DATE,
+                VALID_POLICY_DATE
+            );
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS,
-                VALID_NRIC, VALID_LICENCE_PLATE, VALID_POLICY_NUMBER, VALID_POLICY_DATE, VALID_POLICY_DATE);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+            VALID_NAME,
+            VALID_PHONE,
+            VALID_EMAIL,
+            null,
+            VALID_TAGS,
+            VALID_NRIC,
+            VALID_LICENCE_PLATE,
+            VALID_COMPANY,
+            VALID_POLICY_NUMBER,
+            VALID_POLICY_DATE,
+            VALID_POLICY_DATE
+        );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -119,8 +208,19 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags,
-                        VALID_NRIC, VALID_LICENCE_PLATE, VALID_POLICY_NUMBER, VALID_POLICY_DATE, VALID_POLICY_DATE);
+            new JsonAdaptedPerson(
+                VALID_NAME,
+                VALID_PHONE,
+                VALID_EMAIL,
+                VALID_ADDRESS,
+                invalidTags,
+                VALID_NRIC,
+                VALID_LICENCE_PLATE,
+                VALID_COMPANY,
+                VALID_POLICY_NUMBER,
+                VALID_POLICY_DATE,
+                VALID_POLICY_DATE
+            );
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -10,6 +10,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.policy.Company;
 import seedu.address.model.policy.Policy;
 import seedu.address.model.policy.PolicyDate;
 import seedu.address.model.policy.PolicyNumber;
@@ -27,6 +28,7 @@ public class PersonBuilder {
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     private static final String DEFAULT_NRIC = "567A";
     private static final String DEFAULT_LICENCE_PLATE = "SBC123D";
+    private static final String DEFAULT_COMPANY = "NTUC";
     private static final String DEFAULT_POLICY_NUMBER = "AIA1234";
     private static final String DEFAULT_POLICY_ISSUE_DATE = "01-01-2023";
     private static final String DEFAULT_POLICY_EXPIRY_DATE = "01-01-2030";
@@ -51,10 +53,11 @@ public class PersonBuilder {
         tags = new HashSet<>();
         nric = new Nric(DEFAULT_NRIC);
         licencePlate = new LicencePlate(DEFAULT_LICENCE_PLATE);
+        Company company = new Company(DEFAULT_COMPANY);
         PolicyNumber policyNumber = new PolicyNumber(DEFAULT_POLICY_NUMBER);
         PolicyDate policyIssueDate = new PolicyDate(DEFAULT_POLICY_ISSUE_DATE);
         PolicyDate policyExpiryDate = new PolicyDate(DEFAULT_POLICY_EXPIRY_DATE);
-        policy = new Policy(policyNumber, policyIssueDate, policyExpiryDate);
+        policy = new Policy(company, policyNumber, policyIssueDate, policyExpiryDate);
     }
 
     /**
@@ -130,8 +133,8 @@ public class PersonBuilder {
     /**
      * Sets the {@code Policy} of the {@code Person} that we are building.
      */
-    public PersonBuilder withPolicy(String policyNumber, String policyIssueDate, String policyExpiryDate) {
-        this.policy = new Policy(new PolicyNumber(policyNumber),
+    public PersonBuilder withPolicy(String company, String policyNumber, String policyIssueDate, String policyExpiryDate) {
+        this.policy = new Policy(new Company(company), new PolicyNumber(policyNumber),
                 new PolicyDate(policyIssueDate), new PolicyDate(policyExpiryDate));
         return this;
     }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -85,7 +85,7 @@ public class PersonBuilder {
     /**
      * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
      */
-    public PersonBuilder withTags(String ... tags) {
+    public PersonBuilder withTags(String... tags) {
         this.tags = SampleDataUtil.getTagSet(tags);
         return this;
     }
@@ -133,9 +133,14 @@ public class PersonBuilder {
     /**
      * Sets the {@code Policy} of the {@code Person} that we are building.
      */
-    public PersonBuilder withPolicy(String company, String policyNumber, String policyIssueDate, String policyExpiryDate) {
+    public PersonBuilder withPolicy(
+        String company,
+        String policyNumber,
+        String policyIssueDate,
+        String policyExpiryDate
+    ) {
         this.policy = new Policy(new Company(company), new PolicyNumber(policyNumber),
-                new PolicyDate(policyIssueDate), new PolicyDate(policyExpiryDate));
+            new PolicyDate(policyIssueDate), new PolicyDate(policyExpiryDate));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -2,6 +2,8 @@ package seedu.address.testutil;
 
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LICENCE_PLATE_AMY;
@@ -37,28 +39,28 @@ public class TypicalPersons {
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253")
             .withTags("friends").withNric("000A").withLicencePlate("SBA1234A")
-            .withPolicy("AIA1", "01-01-2020", "01-02-2020").build();
+            .withPolicy("NTUC", "AIA1", "01-01-2020", "01-02-2020").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends").withNric("001B").withLicencePlate("SBA5555B")
-            .withPolicy("AIA2", "12-12-2010", "12-12-2020").build();
+            .withPolicy("InsureMe", "AIA2", "12-12-2010", "12-12-2020").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withNric("123C").withLicencePlate("SLR8E")
-            .withPolicy("5734534X", "31-12-2019", "01-01-2020").build();
+            .withPolicy("InsureMe", "5734534X", "31-12-2019", "01-01-2020").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends")
             .withNric("464J").withLicencePlate("STG46P")
-            .withPolicy("NTUC4532", "29-02-2004", "29-02-2008").build();
+            .withPolicy("NTUC", "4532", "29-02-2004", "29-02-2008").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave").withNric("573H").withLicencePlate("SHL463C")
-            .withPolicy("NOPOLICY", "01-01-1000", "01-01-1000").build();
+            .withPolicy("NTUC", "NOPOLICY", "01-01-1000", "01-01-1000").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo").withNric("743G").withLicencePlate("SBA1Z")
-            .withPolicy("NOPOLICY", "01-01-1000", "01-01-1000").build();
+            .withPolicy("InsureMe", "NOPOLICY", "01-01-1000", "01-01-1000").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
             .withEmail("anna@example.com").withAddress("4th street").withNric("674G").withLicencePlate("SNM9735R")
-            .withPolicy("NOPOLICY", "01-01-1000", "01-01-1000").build();
+            .withPolicy("InsureMe", "NOPOLICY", "01-01-1000", "01-01-1000").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
@@ -70,11 +72,23 @@ public class TypicalPersons {
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND)
             .withNric(VALID_NRIC_AMY).withLicencePlate(VALID_LICENCE_PLATE_AMY)
-            .withPolicy(VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build();
+            .withPolicy(
+                VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY,
+                VALID_POLICY_ISSUE_DATE_AMY,
+                VALID_POLICY_EXPIRY_DATE_AMY
+            )
+        .build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
             .withNric(VALID_NRIC_BOB).withLicencePlate(VALID_LICENCE_PLATE_BOB)
-            .withPolicy(VALID_POLICY_NO_BOB, VALID_POLICY_ISSUE_DATE_BOB, VALID_POLICY_EXPIRY_DATE_BOB).build();
+            .withPolicy(
+                VALID_COMPANY_BOB,
+                VALID_POLICY_NO_BOB,
+                VALID_POLICY_ISSUE_DATE_BOB,
+                VALID_POLICY_EXPIRY_DATE_BOB
+            )
+        .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 


### PR DESCRIPTION
- Add `company` field to `Policy`.
- Update all files effected due to the changes.
- Update Company field in the pre-existing dummy Persons for test cases.
- Update all test cases affected.

Now agent can specify a Company to a Policy, helping him better sort his clients.

Closes #85 