### PR TITLE
Implement remind feature with user input criteria

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -13,20 +13,14 @@ import seedu.address.model.person.Person;
 public class Messages {
 
     public static final String MESSAGE_NOT_FOUND_INDEX = "Error: Invalid Index";
-
     public static final String MESSAGE_MISSING_INDEX = "Error: Missing Index";
-
     public static final String MESSAGE_IMPOSSIBLE_INDEX = "Error: The parameter is not of the type positive integer";
-
     public static final String MESSAGE_PREAMBLE_DETECTED = "Error: Preamble Detected";
-
     public static final String MESSAGE_USED_POLICY_NUMBER = "Error: The policy number is already in use";
-
     public static final String MESSAGE_MISSING_FIELDS_FOR_ADD_COMMAND =
             "Error: Some of the required fields are missing. "
             + "\n"
             + "Please include the following: ";
-
     public static final String MESSAGE_MISSING_FIELDS_POLICY_FOR_ADD_COMMAND =
             "Please include either all or none of the policy variables. "
             + "\n"
@@ -37,6 +31,8 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_NOT_NUMBERS = "Error: The value is not a number";
+    public static final String MESSAGE_NOT_POSITIVE_NUMBER = "Error: The value has to be 0 or more";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -77,6 +77,17 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        assert namePredicate != null : "Name Predicate should never be null";
+        assert licencePredicate != null : "Licence plate predicate should never be null";
+        assert nricPredicate != null : "NRIC predicate should never be null";
+        assert phonePredicate != null : "Phone predicate should never be null";
+        assert policyNumberPredicate != null : "Policy number predicate should never be null";
+        assert tagPredicate != null : "Tag predicate should never be null";
+        assert policyExpiryPredicate != null : "Policy expiry predicate should never be null";
+        assert emailPredicate != null : "Email predicate should never be null";
+        assert policyIssuePredicate != null : "Policy issue predicate should never be null";
+        assert companyPredicate != null : "Company predicate should never be null";
+        
         List<Predicate<Person>> predicates = addAllToPredicatesList();
         model.updateFilteredPersonList(PredicateUtil.combinePredicates(predicates));
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -87,7 +87,6 @@ public class FindCommand extends Command {
         assert emailPredicate != null : "Email predicate should never be null";
         assert policyIssuePredicate != null : "Policy issue predicate should never be null";
         assert companyPredicate != null : "Company predicate should never be null";
-        
         List<Predicate<Person>> predicates = addAllToPredicatesList();
         model.updateFilteredPersonList(PredicateUtil.combinePredicates(predicates));
 

--- a/src/main/java/seedu/address/logic/commands/RemindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemindCommand.java
@@ -13,10 +13,16 @@ public class RemindCommand extends Command {
 
     public static final String COMMAND_WORD = "remind";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose policy expiry dates is within "
+            + "the specified number of days.\n"
+            + "Parameters: Number of days\n"
+            + "Example: " + COMMAND_WORD + " 30";
+
     private final RemindPredicate remindPredicate;
 
+
     /**
-     * Constructor for FindCommand.
+     * Constructor for RemindCommand.
      *
      * @param remindPredicate the predicate to be used for filtering the persons list based on policy expiry date.
      */
@@ -27,6 +33,7 @@ public class RemindCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        assert remindPredicate != null : "Predicate should never be null";
         model.updateFilteredPersonList(remindPredicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));

--- a/src/main/java/seedu/address/logic/parser/RemindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemindCommandParser.java
@@ -23,6 +23,7 @@ public class RemindCommandParser implements Parser<RemindCommand> {
 
         try {
             int parsedArgs = Integer.parseInt(trimmedArgs);
+
             if (parsedArgs < 0) {
                 throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
                         Messages.MESSAGE_NOT_POSITIVE_NUMBER));

--- a/src/main/java/seedu/address/logic/parser/RemindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemindCommandParser.java
@@ -27,6 +27,7 @@ public class RemindCommandParser implements Parser<RemindCommand> {
                 throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
                         Messages.MESSAGE_NOT_POSITIVE_NUMBER));
             }
+            
             return new RemindCommand(new RemindPredicate(parsedArgs));
         } catch (NumberFormatException e) {
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,

--- a/src/main/java/seedu/address/logic/parser/RemindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemindCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.RemindCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.RemindPredicate;
 
 /**
@@ -8,10 +10,27 @@ import seedu.address.model.person.RemindPredicate;
  */
 public class RemindCommandParser implements Parser<RemindCommand> {
     /**
-     * Parses the given {@code String} of arguments in the context of the SortCommand
-     * and returns a SortCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the RemindCommand
+     * and returns a RemindCommand object for execution.
      */
-    public RemindCommand parse(String args) {
-        return new RemindCommand(new RemindPredicate());
+    public RemindCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, RemindCommand.MESSAGE_USAGE));
+        }
+
+        try {
+            int parsedArgs = Integer.parseInt(trimmedArgs);
+            if (parsedArgs < 0) {
+                throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                        Messages.MESSAGE_NOT_POSITIVE_NUMBER));
+            }
+            return new RemindCommand(new RemindPredicate(parsedArgs));
+        } catch (NumberFormatException e) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    Messages.MESSAGE_NOT_NUMBERS));
+        }
     }
 }

--- a/src/main/java/seedu/address/model/person/RemindPredicate.java
+++ b/src/main/java/seedu/address/model/person/RemindPredicate.java
@@ -10,11 +10,37 @@ import java.util.function.Predicate;
 public class RemindPredicate implements Predicate<Person> {
 
     private static final int VALID_DAYS_STARTS_FROM = 0;
-    private static final int DUE_DAYS = 31;
+    private final int days;
+
+    /**
+     * Constructor for RemindPredicate.
+     *
+     * @param days the number of days to be used for the range to check with.
+     */
+    public RemindPredicate(int days) {
+        assert days >= 0;
+        this.days = days;
+    }
 
     @Override
     public boolean test(Person person) {
         long dueDays = ChronoUnit.DAYS.between(LocalDate.now(), person.getPolicy().getPolicyExpiryDate().date);
-        return dueDays >= VALID_DAYS_STARTS_FROM && dueDays <= DUE_DAYS;
+        return dueDays >= VALID_DAYS_STARTS_FROM && dueDays <= days;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RemindPredicate)) {
+            return false;
+        }
+
+        RemindPredicate otherNameContainsKeywordsPredicate =
+                (RemindPredicate) other;
+        return days == otherNameContainsKeywordsPredicate.days;
     }
 }


### PR DESCRIPTION
Closes #95 

Revamped remind command to now allow users to enter the number of days from the current date they want to see whose persons' policy expiry date is within that range.

Example:
`remind 30` shows persons with policy expiry dates that are within 30 days from the current date