### PR TITLE
Fix a bug in the find command for policy expiry and issue dates

### DIFF
--- a/src/main/java/seedu/address/model/person/PolicyExpiryContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PolicyExpiryContainsKeywordsPredicate.java
@@ -1,6 +1,7 @@
 package seedu.address.model.person;
 
 import seedu.address.commons.util.StringUtil;
+import seedu.address.model.policy.PolicyDate;
 
 /**
  * Tests that a {@code Person}'s {@code Policy Expiry date} matches any of the keywords given.
@@ -13,8 +14,8 @@ public class PolicyExpiryContainsKeywordsPredicate extends FieldPredicates {
 
     @Override
     public boolean test(Person person) {
-        return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
+        return !person.getPolicy().getPolicyExpiryDate().toString().equals(PolicyDate.DEFAULT_VALUE)
+                && keywords.stream().anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
                         person.getPolicy().getPolicyExpiryDate().toString(), keyword));
     }
 

--- a/src/main/java/seedu/address/model/person/PolicyIssueContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PolicyIssueContainsKeywordsPredicate.java
@@ -1,6 +1,7 @@
 package seedu.address.model.person;
 
 import seedu.address.commons.util.StringUtil;
+import seedu.address.model.policy.PolicyDate;
 
 /**
  * Tests that a {@code Person}'s {@code Policy Issue date} matches any of the keywords given.
@@ -13,8 +14,8 @@ public class PolicyIssueContainsKeywordsPredicate extends FieldPredicates {
 
     @Override
     public boolean test(Person person) {
-        return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
+        return !person.getPolicy().getPolicyExpiryDate().toString().equals(PolicyDate.DEFAULT_VALUE)
+                && keywords.stream().anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
                         person.getPolicy().getPolicyIssueDate().toString(), keyword));
     }
 


### PR DESCRIPTION
Closes #76

Now when user uses the command with either `find pi/01-01` or `find pe/01-01` , it will not display the persons with the default policy date of `01-01-1000`.