### PR TITLE
Add exception handlings for remind feature

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -32,7 +32,8 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_NOT_NUMBERS = "Error: The value is not a number";
-    public static final String MESSAGE_NOT_POSITIVE_NUMBER = "Error: The value has to be 0 or more";
+    public static final String MESSAGE_NOT_IN_RANGE =
+            "Error: The value has to be between %1$d and %2$d (both inclusive)";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/parser/RemindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemindCommandParser.java
@@ -9,6 +9,9 @@ import seedu.address.model.person.RemindPredicate;
  * Parses input arguments and creates a new RemindCommand object
  */
 public class RemindCommandParser implements Parser<RemindCommand> {
+
+    private static final int VALID_DAYS_FROM = 0;
+    private static final int VALID_DAYS_TO = 7305;
     /**
      * Parses the given {@code String} of arguments in the context of the RemindCommand
      * and returns a RemindCommand object for execution.
@@ -24,9 +27,8 @@ public class RemindCommandParser implements Parser<RemindCommand> {
         try {
             int parsedArgs = Integer.parseInt(trimmedArgs);
 
-            if (parsedArgs < 0) {
-                throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                        Messages.MESSAGE_NOT_POSITIVE_NUMBER));
+            if (parsedArgs < VALID_DAYS_FROM || parsedArgs > VALID_DAYS_TO) {
+                throw new ParseException(String.format(Messages.MESSAGE_NOT_IN_RANGE, VALID_DAYS_FROM, VALID_DAYS_TO));
             }
             return new RemindCommand(new RemindPredicate(parsedArgs));
         } catch (NumberFormatException e) {

--- a/src/main/java/seedu/address/model/person/RemindPredicate.java
+++ b/src/main/java/seedu/address/model/person/RemindPredicate.java
@@ -8,8 +8,6 @@ import java.util.function.Predicate;
  * Tests that a {@code Person}'s {@code Policy Expiry Date}is within a certain period from the current date.
  */
 public class RemindPredicate implements Predicate<Person> {
-
-    private static final int VALID_DAYS_STARTS_FROM = 0;
     private final int days;
 
     /**
@@ -24,8 +22,7 @@ public class RemindPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        long dueDays = ChronoUnit.DAYS.between(LocalDate.now(), person.getPolicy().getPolicyExpiryDate().date);
-        return dueDays >= VALID_DAYS_STARTS_FROM && dueDays <= days;
+        return ChronoUnit.DAYS.between(LocalDate.now(), person.getPolicy().getPolicyExpiryDate().date) <= days;
     }
 
     @Override


### PR DESCRIPTION
Closes #96 

3 kinds of error can occur according to user input:
1. Number of days given is less than 0 or more than 7305 e.g. `remind -1` : `Error: The value has to be between 0 and 7305 (both inclusive)`
2. Number of days given is not a number e.g. `remind ten` : `Invalid command format! Error: The value is not a number`
3. Number of days is not given e.g. `remind ` : `Invalid command format! remind: Finds all persons whose policy expiry dates is within the specified number of days. Parameters: Number of days Example: remind 30`