### PR TITLE
Handle exceptions in find command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -157,8 +157,6 @@ Expected output upon success:<br>
 ![FindSuccess](images/FindSuccess.png)
 
 Expected output upon failure:
-* Format error in any field:<br>
-`Error: Please adhere to the format for the fields`
 * No field given:
 ```
 Invalid command format!  
@@ -168,7 +166,7 @@ At least one parameter must be present.
 Example: find n/Alice Rodriguez
 ```
 * Field flag given but no value:<br>
-`Error: Please give a value in the field(s) indicated`
+`Error: No value detected for the following field(s): `
 
 
 ### Deleting a client : `delete`

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -38,7 +38,8 @@ public class Messages {
     public static final String MESSAGE_NOT_IN_RANGE =
             "Error: The value has to be between %1$d and %2$d (both inclusive)";
     public static final String MESSAGE_INVALID_TWO_FIELD = "Error: Please contain only either "
-            + "one field of %1$s or %1$s.";
+            + "one field of %1$s or %2$s.";
+    public static final String MESSAGE_EMPTY_FIELDS = "Error: No value detected for the following field(s): %1$s";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_FIELDS;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -53,6 +54,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                 PREFIX_NRIC, PREFIX_LICENCE_PLATE, PREFIX_POLICY_NUMBER, PREFIX_POLICY_ISSUE_DATE,
                 PREFIX_POLICY_EXPIRY_DATE);
 
+        // Get keywords to find by
         String nameKeyword = "";
         String licenceKeyword = "";
         String nricKeyword = "";
@@ -64,35 +66,87 @@ public class FindCommandParser implements Parser<FindCommand> {
         String policyIssueKeyword = "";
         String companyKeyword = "";
 
+        String emptyPrefixes = "";
+        boolean atLeastOneFieldPresent = false;
+
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             nameKeyword = argMultimap.getValue(PREFIX_NAME).get();
+            if (nameKeyword.isEmpty()) {
+                emptyPrefixes += PREFIX_NAME + " ";
+            }
+            atLeastOneFieldPresent = true;
         }
         if (argMultimap.getValue(PREFIX_LICENCE_PLATE).isPresent()) {
             licenceKeyword = argMultimap.getValue(PREFIX_LICENCE_PLATE).get();
+            if (licenceKeyword.isEmpty()) {
+                emptyPrefixes += PREFIX_LICENCE_PLATE + " ";
+            }
+            atLeastOneFieldPresent = true;
         }
         if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
             nricKeyword = argMultimap.getValue(PREFIX_NRIC).get();
+            if (nricKeyword.isEmpty()) {
+                emptyPrefixes += PREFIX_NRIC + " ";
+            }
+            atLeastOneFieldPresent = true;
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
             phoneKeyword = argMultimap.getValue(PREFIX_PHONE).get();
+            if (phoneKeyword.isEmpty()) {
+                emptyPrefixes += PREFIX_PHONE + " ";
+            }
+            atLeastOneFieldPresent = true;
         }
         if (argMultimap.getValue(PREFIX_POLICY_NUMBER).isPresent()) {
             policyNumberKeyword = argMultimap.getValue(PREFIX_POLICY_NUMBER).get();
+            if (policyNumberKeyword.isEmpty()) {
+                emptyPrefixes += PREFIX_POLICY_NUMBER + " ";
+            }
+            atLeastOneFieldPresent = true;
         }
         if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
             tagKeyword = argMultimap.getValue(PREFIX_TAG).get();
+            if (tagKeyword.isEmpty()) {
+                emptyPrefixes += PREFIX_TAG + " ";
+            }
+            atLeastOneFieldPresent = true;
         }
         if (argMultimap.getValue(PREFIX_POLICY_EXPIRY_DATE).isPresent()) {
             policyExpiryKeyword = argMultimap.getValue(PREFIX_POLICY_EXPIRY_DATE).get();
+            if (policyExpiryKeyword.isEmpty()) {
+                emptyPrefixes += PREFIX_POLICY_EXPIRY_DATE + " ";
+            }
+            atLeastOneFieldPresent = true;
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
             emailKeyword = argMultimap.getValue(PREFIX_EMAIL).get();
+            if (emailKeyword.isEmpty()) {
+                emptyPrefixes += PREFIX_EMAIL + " ";
+            }
+            atLeastOneFieldPresent = true;
         }
         if (argMultimap.getValue(PREFIX_POLICY_ISSUE_DATE).isPresent()) {
             policyIssueKeyword = argMultimap.getValue(PREFIX_POLICY_ISSUE_DATE).get();
+            if (policyIssueKeyword.isEmpty()) {
+                emptyPrefixes += PREFIX_POLICY_ISSUE_DATE + " ";
+            }
+            atLeastOneFieldPresent = true;
         }
         if (argMultimap.getValue(PREFIX_COMPANY).isPresent()) {
             companyKeyword = argMultimap.getValue(PREFIX_COMPANY).get();
+            if (companyKeyword.isEmpty()) {
+                emptyPrefixes += PREFIX_COMPANY + " ";
+            }
+            atLeastOneFieldPresent = true;
+        }
+
+        if (!atLeastOneFieldPresent) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
+        if (!emptyPrefixes.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_EMPTY_FIELDS, emptyPrefixes.trim()));
         }
 
         return new FindCommand(new NameContainsKeywordsPredicate(nameKeyword),


### PR DESCRIPTION
Closes #66 

- Updated UG to reflect expected output

Additional exceptions handled:
- No fields given (e.g. `find`, `find a`)
- Empty fields