### PR TITLE
Add tests for remind command and enhanced features

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RemindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemindCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.predicates.RemindPredicate;
@@ -37,5 +38,27 @@ public class RemindCommand extends Command {
         model.updateFilteredPersonList(remindPredicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RemindCommand)) {
+            return false;
+        }
+
+        RemindCommand otherFindCommand = (RemindCommand) other;
+        return remindPredicate.equals(otherFindCommand.remindPredicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("remind predicate", remindPredicate)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/model/person/predicates/PolicyNumberContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/PolicyNumberContainsKeywordsPredicate.java
@@ -14,8 +14,7 @@ public class PolicyNumberContainsKeywordsPredicate extends FieldPredicates {
 
     @Override
     public boolean test(Person person) {
-        return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
+        return !person.hasDefaultPolicy() && keywords.stream().anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
                         person.getPolicy().getPolicyNumber().value, keyword));
     }
 

--- a/src/main/java/seedu/address/model/person/predicates/RemindPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/RemindPredicate.java
@@ -26,7 +26,7 @@ public class RemindPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         long dayDifference = ChronoUnit.DAYS.between(LocalDate.now(), person.getPolicy().getPolicyExpiryDate().date);
-        return !person.hasDefaultPolicy() && dayDifference >= 0 && dayDifference <= days;
+        return !person.hasDefaultPolicy() && dayDifference >= NON_EXPIRY_DAY && dayDifference <= days;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/predicates/RemindPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/RemindPredicate.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.function.Predicate;
 
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.person.Person;
 
 /**
@@ -43,5 +44,10 @@ public class RemindPredicate implements Predicate<Person> {
         RemindPredicate otherNameContainsKeywordsPredicate =
                 (RemindPredicate) other;
         return days == otherNameContainsKeywordsPredicate.days;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("days", days).toString();
     }
 }

--- a/src/main/java/seedu/address/model/person/predicates/RemindPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/RemindPredicate.java
@@ -7,7 +7,7 @@ import java.util.function.Predicate;
 import seedu.address.model.person.Person;
 
 /**
- * Tests that a {@code Person}'s {@code Policy Expiry Date}is within a certain period from the current date.
+ * Tests that a {@code Person}'s {@code Policy Expiry Date} is within a certain period from the current date.
  */
 public class RemindPredicate implements Predicate<Person> {
     private static final int NON_EXPIRY_DAY = 0;

--- a/src/main/java/seedu/address/model/policy/PolicyNumber.java
+++ b/src/main/java/seedu/address/model/policy/PolicyNumber.java
@@ -28,7 +28,7 @@ public class PolicyNumber {
     public PolicyNumber(String policyNumber) {
         requireNonNull(policyNumber);
         checkArgument(isValidPolicyNumber(policyNumber), MESSAGE_CONSTRAINTS);
-        value = policyNumber;
+        value = policyNumber.toUpperCase();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/RemindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemindCommandTest.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.predicates.RemindPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code RemindCommand}.
+ */
+public class RemindCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        RemindPredicate firstRemindPredicate = new RemindPredicate(0);
+        RemindPredicate secondRemindPredicate = new RemindPredicate(30);
+
+        RemindCommand firstRemindCommand = new RemindCommand(firstRemindPredicate);
+        RemindCommand secondRemindCommand = new RemindCommand(secondRemindPredicate);
+
+        // same object -> returns true
+        assertTrue(firstRemindCommand.equals(firstRemindCommand));
+
+        // same values -> returns true
+        RemindCommand firstRemindCommandCopy = new RemindCommand(firstRemindPredicate);
+        assertTrue(firstRemindCommand.equals(firstRemindCommandCopy));
+
+        // different types -> returns false
+        assertFalse(firstRemindCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(firstRemindCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstRemindCommand.equals(secondRemindCommand));
+    }
+
+    @Test
+    public void execute_noPolicyExpiryIn30Days_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        RemindPredicate predicate = new RemindPredicate(30);
+
+        RemindCommand command = new RemindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void toStringMethod() {
+        RemindPredicate predicate = new RemindPredicate(30);
+        RemindCommand remindCommand = new RemindCommand(predicate);
+
+        String expected = RemindCommand.class.getCanonicalName() + "{remind predicate=" + predicate + "}";
+        assertEquals(expected, remindCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/RemindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RemindCommandParserTest.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.RemindCommand;
+import seedu.address.model.person.predicates.RemindPredicate;
+
+public class RemindCommandParserTest {
+
+    private RemindCommandParser parser = new RemindCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, RemindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_argsNotNumbers_throwsParseException() {
+        assertParseFailure(parser, " abcd", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, Messages.MESSAGE_NOT_NUMBERS));
+    }
+
+    @Test
+    public void parse_argsNotInRange_throwsParseException() {
+        assertParseFailure(parser, " -1", String.format(Messages.MESSAGE_NOT_IN_RANGE, 0, 7305));
+        assertParseFailure(parser, " 8000", String.format(Messages.MESSAGE_NOT_IN_RANGE, 0, 7305));
+    }
+
+    @Test
+    public void parse_validArgs_returnsRemindCommand() {
+        // no leading and trailing whitespaces
+        RemindCommand expectedRemindCommand = new RemindCommand(new RemindPredicate(30));
+        assertParseSuccess(parser, " 30", expectedRemindCommand);
+    }
+
+}

--- a/src/test/java/seedu/address/model/person/predicates/CompanyContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/CompanyContainsKeywordsPredicateTest.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_NO_AMY;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.policy.Company;
 import seedu.address.testutil.PersonBuilder;
 
 public class CompanyContainsKeywordsPredicateTest {
@@ -79,6 +80,15 @@ public class CompanyContainsKeywordsPredicateTest {
         predicate = new CompanyContainsKeywordsPredicate("FWD Insurance 123");
         assertFalse(predicate.test(new PersonBuilder().withPolicy("FWD Insurance",
                 VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+    }
+
+    @Test
+    public void test_companyIsDefault_returnsFalse() {
+        // Company is the default parameter
+        CompanyContainsKeywordsPredicate predicate =
+                new CompanyContainsKeywordsPredicate("FWD Insurance");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(Company.DEFAULT_VALUE, VALID_POLICY_NO_AMY,
+                VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/predicates/CompanyContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/CompanyContainsKeywordsPredicateTest.java
@@ -1,0 +1,92 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_EXPIRY_DATE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_ISSUE_DATE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_NO_AMY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class CompanyContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "first second";
+
+        CompanyContainsKeywordsPredicate firstPredicate = new CompanyContainsKeywordsPredicate(firstPredicateKeyword);
+        CompanyContainsKeywordsPredicate secondPredicate = new CompanyContainsKeywordsPredicate(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        CompanyContainsKeywordsPredicate firstPredicateCopy =
+                new CompanyContainsKeywordsPredicate(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_companyContainsKeywords_returnsTrue() {
+        // One keyword
+        CompanyContainsKeywordsPredicate predicate =
+                new CompanyContainsKeywordsPredicate("FWD Insurance");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy("FWD Insurance",
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Trailing and Leading white spaces
+        predicate = new CompanyContainsKeywordsPredicate("   FWD Insurance    ");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy("FWD Insurance",
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Mixed-case keywords
+        predicate = new CompanyContainsKeywordsPredicate("fWd InsURanCe");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy("FWD Insurance",
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Partial keyword
+        predicate = new CompanyContainsKeywordsPredicate("FWD");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy("FWD Insurance",
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+    }
+
+    @Test
+    public void test_companyDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keyword
+        CompanyContainsKeywordsPredicate predicate = new CompanyContainsKeywordsPredicate("ABC");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy("FWD Insurance",
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Keyword only matches word that is separated by white space
+        predicate = new CompanyContainsKeywordsPredicate("ABC Insurance");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy("ABCInsurance",
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Keyword do not match exact
+        predicate = new CompanyContainsKeywordsPredicate("FWD Insurance 123");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy("FWD Insurance",
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "keyword1";
+        CompanyContainsKeywordsPredicate predicate = new CompanyContainsKeywordsPredicate(keyword);
+
+        String expected = CompanyContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=[" + keyword + "]}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/EmailContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/EmailContainsKeywordsPredicateTest.java
@@ -1,0 +1,80 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class EmailContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "first second";
+
+        EmailContainsKeywordsPredicate firstPredicate = new EmailContainsKeywordsPredicate(firstPredicateKeyword);
+        EmailContainsKeywordsPredicate secondPredicate = new EmailContainsKeywordsPredicate(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        EmailContainsKeywordsPredicate firstPredicateCopy = new EmailContainsKeywordsPredicate(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_emailContainsKeywords_returnsTrue() {
+        // One keyword
+        EmailContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate("amy@example.com");
+        assertTrue(predicate.test(new PersonBuilder().withEmail("amy@example.com").build()));
+
+        // Trailing and Leading white spaces
+        predicate = new EmailContainsKeywordsPredicate("   amy@example.com    ");
+        assertTrue(predicate.test(new PersonBuilder().withEmail("amy@example.com").build()));
+
+        // Mixed-case keywords
+        predicate = new EmailContainsKeywordsPredicate("AmY@ExAmPle.coM");
+        assertTrue(predicate.test(new PersonBuilder().withEmail("amy@example.com").build()));
+
+        // Partial keyword
+        predicate = new EmailContainsKeywordsPredicate("amy");
+        assertTrue(predicate.test(new PersonBuilder().withEmail("amy@example.com").build()));
+    }
+
+    @Test
+    public void test_emailDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keyword
+        EmailContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate("bob");
+        assertFalse(predicate.test(new PersonBuilder().withEmail("amy@example.com").build()));
+
+        // Keyword including white spaces
+        predicate = new EmailContainsKeywordsPredicate("amy @example. com");
+        assertFalse(predicate.test(new PersonBuilder().withEmail("amy@example.com").build()));
+
+        // Keyword do not match exact
+        predicate = new EmailContainsKeywordsPredicate("amykim@example.com");
+        assertFalse(predicate.test(new PersonBuilder().withEmail("amy@example.com").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "keyword1";
+        EmailContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate(keyword);
+
+        String expected = EmailContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=[" + keyword + "]}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/LicenceContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/LicenceContainsKeywordsPredicateTest.java
@@ -1,0 +1,81 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class LicenceContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "first second";
+
+        LicenceContainsKeywordsPredicate firstPredicate = new LicenceContainsKeywordsPredicate(firstPredicateKeyword);
+        LicenceContainsKeywordsPredicate secondPredicate = new LicenceContainsKeywordsPredicate(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        LicenceContainsKeywordsPredicate firstPredicateCopy =
+                new LicenceContainsKeywordsPredicate(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_licenceContainsKeywords_returnsTrue() {
+        // One keyword
+        LicenceContainsKeywordsPredicate predicate = new LicenceContainsKeywordsPredicate("SLA1111A");
+        assertTrue(predicate.test(new PersonBuilder().withLicencePlate("SLA1111A").build()));
+
+        // Trailing and Leading white spaces
+        predicate = new LicenceContainsKeywordsPredicate("   SLA1111A    ");
+        assertTrue(predicate.test(new PersonBuilder().withLicencePlate("SLA1111A").build()));
+
+        // Mixed-case keywords
+        predicate = new LicenceContainsKeywordsPredicate("slA1111a");
+        assertTrue(predicate.test(new PersonBuilder().withLicencePlate("SLA1111A").build()));
+
+        // Partial keyword
+        predicate = new LicenceContainsKeywordsPredicate("SLA");
+        assertTrue(predicate.test(new PersonBuilder().withLicencePlate("SLA1111A").build()));
+    }
+
+    @Test
+    public void test_licenceDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keyword
+        LicenceContainsKeywordsPredicate predicate = new LicenceContainsKeywordsPredicate("2222");
+        assertFalse(predicate.test(new PersonBuilder().withLicencePlate("SLA1111A").build()));
+
+        // Keyword including white spaces
+        predicate = new LicenceContainsKeywordsPredicate("SLA 1111A");
+        assertFalse(predicate.test(new PersonBuilder().withLicencePlate("SLA1111A").build()));
+
+        // Keyword do not match exact
+        predicate = new LicenceContainsKeywordsPredicate("SLAB1111A");
+        assertFalse(predicate.test(new PersonBuilder().withLicencePlate("SLA1111A").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "keyword1";
+        LicenceContainsKeywordsPredicate predicate = new LicenceContainsKeywordsPredicate(keyword);
+
+        String expected = LicenceContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=[" + keyword + "]}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicateTest.java
@@ -1,4 +1,4 @@
-package seedu.address.model.person;
+package seedu.address.model.person.predicates;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
 import seedu.address.testutil.PersonBuilder;
 
 public class NameContainsKeywordsPredicateTest {
@@ -39,8 +38,7 @@ public class NameContainsKeywordsPredicateTest {
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
-        NameContainsKeywordsPredicate predicate =
-                new NameContainsKeywordsPredicate("Alice Bob");
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate("Alice Bob");
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Trailing and Leading white spaces
@@ -50,16 +48,24 @@ public class NameContainsKeywordsPredicateTest {
         // Mixed-case keywords
         predicate = new NameContainsKeywordsPredicate("aLIce bOB");
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Partial keyword
+        predicate = new NameContainsKeywordsPredicate("Ali");
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate("test");
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
-
         // Non-matching keyword
-        predicate = new NameContainsKeywordsPredicate("Carol");
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate("Carol");
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Keyword only matches word that is separated by white space
+        predicate = new NameContainsKeywordsPredicate("Alice Bob");
+        assertFalse(predicate.test(new PersonBuilder().withName("AliceBob").build()));
+
+        // Keyword do not match exact
+        predicate = new NameContainsKeywordsPredicate("Alice Bob Carol");
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 

--- a/src/test/java/seedu/address/model/person/predicates/NricContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/NricContainsKeywordsPredicateTest.java
@@ -1,0 +1,80 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class NricContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "first second";
+
+        NricContainsKeywordsPredicate firstPredicate = new NricContainsKeywordsPredicate(firstPredicateKeyword);
+        NricContainsKeywordsPredicate secondPredicate = new NricContainsKeywordsPredicate(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        NricContainsKeywordsPredicate firstPredicateCopy = new NricContainsKeywordsPredicate(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nricContainsKeywords_returnsTrue() {
+        // One keyword
+        NricContainsKeywordsPredicate predicate = new NricContainsKeywordsPredicate("987A");
+        assertTrue(predicate.test(new PersonBuilder().withNric("987A").build()));
+
+        // Trailing and Leading white spaces
+        predicate = new NricContainsKeywordsPredicate("   987A    ");
+        assertTrue(predicate.test(new PersonBuilder().withNric("987A").build()));
+
+        // Mixed-case keywords
+        predicate = new NricContainsKeywordsPredicate("987a");
+        assertTrue(predicate.test(new PersonBuilder().withNric("987A").build()));
+
+        // Partial keyword
+        predicate = new NricContainsKeywordsPredicate("98");
+        assertTrue(predicate.test(new PersonBuilder().withNric("987A").build()));
+    }
+
+    @Test
+    public void test_nricDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keyword
+        NricContainsKeywordsPredicate predicate = new NricContainsKeywordsPredicate("123");
+        assertFalse(predicate.test(new PersonBuilder().withNric("987A").build()));
+
+        // Keyword including white spaces
+        predicate = new NricContainsKeywordsPredicate("98 7A");
+        assertFalse(predicate.test(new PersonBuilder().withNric("987A").build()));
+
+        // Keyword do not match exact
+        predicate = new NricContainsKeywordsPredicate("987AB");
+        assertFalse(predicate.test(new PersonBuilder().withNric("987A").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "keyword1";
+        NricContainsKeywordsPredicate predicate = new NricContainsKeywordsPredicate(keyword);
+
+        String expected = NricContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=[" + keyword + "]}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/PhoneContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/PhoneContainsKeywordsPredicateTest.java
@@ -1,0 +1,76 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class PhoneContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "first second";
+
+        PhoneContainsKeywordsPredicate firstPredicate = new PhoneContainsKeywordsPredicate(firstPredicateKeyword);
+        PhoneContainsKeywordsPredicate secondPredicate = new PhoneContainsKeywordsPredicate(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        PhoneContainsKeywordsPredicate firstPredicateCopy = new PhoneContainsKeywordsPredicate(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_phoneContainsKeywords_returnsTrue() {
+        // One keyword
+        PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate("98765432");
+        assertTrue(predicate.test(new PersonBuilder().withPhone("98765432").build()));
+
+        // Trailing and Leading white spaces
+        predicate = new PhoneContainsKeywordsPredicate("   98765432    ");
+        assertTrue(predicate.test(new PersonBuilder().withPhone("98765432").build()));
+
+        // Partial keyword
+        predicate = new PhoneContainsKeywordsPredicate("9876");
+        assertTrue(predicate.test(new PersonBuilder().withPhone("98765432").build()));
+    }
+
+    @Test
+    public void test_phoneDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keyword
+        PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate("123");
+        assertFalse(predicate.test(new PersonBuilder().withPhone("98765432").build()));
+
+        // Keyword including white spaces
+        predicate = new PhoneContainsKeywordsPredicate("987 654 32");
+        assertFalse(predicate.test(new PersonBuilder().withPhone("98765432").build()));
+
+        // Keyword do not match exact
+        predicate = new PhoneContainsKeywordsPredicate("987654321");
+        assertFalse(predicate.test(new PersonBuilder().withPhone("98765432").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "keyword1";
+        PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(keyword);
+
+        String expected = PhoneContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=[" + keyword + "]}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/PolicyExpiryContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/PolicyExpiryContainsKeywordsPredicateTest.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_NO_AMY;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.policy.PolicyDate;
 import seedu.address.testutil.PersonBuilder;
 
 public class PolicyExpiryContainsKeywordsPredicateTest {
@@ -76,6 +77,15 @@ public class PolicyExpiryContainsKeywordsPredicateTest {
         predicate = new PolicyExpiryContainsKeywordsPredicate("11-11-2022");
         assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
                 VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, "11-11-2023").build()));
+    }
+
+    @Test
+    public void test_policyExpiryIsDefault_returnsFalse() {
+        // Policy expiry date is the default parameter
+        PolicyExpiryContainsKeywordsPredicate predicate =
+                new PolicyExpiryContainsKeywordsPredicate("11-11-2023");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
+                VALID_POLICY_ISSUE_DATE_AMY, PolicyDate.DEFAULT_VALUE).build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/predicates/PolicyExpiryContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/PolicyExpiryContainsKeywordsPredicateTest.java
@@ -1,0 +1,90 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_ISSUE_DATE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_NO_AMY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class PolicyExpiryContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "first second";
+
+        PolicyExpiryContainsKeywordsPredicate firstPredicate =
+                new PolicyExpiryContainsKeywordsPredicate(firstPredicateKeyword);
+        PolicyExpiryContainsKeywordsPredicate secondPredicate =
+                new PolicyExpiryContainsKeywordsPredicate(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        PolicyExpiryContainsKeywordsPredicate firstPredicateCopy =
+                new PolicyExpiryContainsKeywordsPredicate(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_policyExpiryContainsKeywords_returnsTrue() {
+        // One keyword
+        PolicyExpiryContainsKeywordsPredicate predicate =
+                new PolicyExpiryContainsKeywordsPredicate("11-11-2023");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, "11-11-2023").build()));
+
+        // Trailing and Leading white spaces
+        predicate = new PolicyExpiryContainsKeywordsPredicate("   11-11-2023    ");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, "11-11-2023").build()));
+
+        // Partial keyword
+        predicate = new PolicyExpiryContainsKeywordsPredicate("11-11");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, "11-11-2023").build()));
+    }
+
+    @Test
+    public void test_policyExpiryDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keyword
+        PolicyExpiryContainsKeywordsPredicate predicate = new PolicyExpiryContainsKeywordsPredicate("12-12-2022");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, "11-11-2023").build()));
+
+        // Keyword only matches word that is separated by white space
+        predicate = new PolicyExpiryContainsKeywordsPredicate("11 - 11");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, "11-11-2023").build()));
+
+        // Keyword do not match exact
+        predicate = new PolicyExpiryContainsKeywordsPredicate("11-11-2022");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY, VALID_POLICY_ISSUE_DATE_AMY, "11-11-2023").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "keyword1";
+        PolicyExpiryContainsKeywordsPredicate predicate = new PolicyExpiryContainsKeywordsPredicate(keyword);
+
+        String expected = PolicyExpiryContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=["
+                + keyword + "]}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/PolicyIssueContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/PolicyIssueContainsKeywordsPredicateTest.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_NO_AMY;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.policy.PolicyDate;
 import seedu.address.testutil.PersonBuilder;
 
 public class PolicyIssueContainsKeywordsPredicateTest {
@@ -76,6 +77,15 @@ public class PolicyIssueContainsKeywordsPredicateTest {
         predicate = new PolicyIssueContainsKeywordsPredicate("11-11-2022");
         assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
                 VALID_POLICY_NO_AMY, "11-11-2023", VALID_POLICY_EXPIRY_DATE_AMY).build()));
+    }
+
+    @Test
+    public void test_policyIssueIsDefault_returnsFalse() {
+        // Policy issue date is the default parameter
+        PolicyIssueContainsKeywordsPredicate predicate =
+                new PolicyIssueContainsKeywordsPredicate("11-11-2023");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
+                PolicyDate.DEFAULT_VALUE, VALID_POLICY_EXPIRY_DATE_AMY).build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/predicates/PolicyIssueContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/PolicyIssueContainsKeywordsPredicateTest.java
@@ -1,0 +1,90 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_EXPIRY_DATE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_NO_AMY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class PolicyIssueContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "first second";
+
+        PolicyIssueContainsKeywordsPredicate firstPredicate =
+                new PolicyIssueContainsKeywordsPredicate(firstPredicateKeyword);
+        PolicyIssueContainsKeywordsPredicate secondPredicate =
+                new PolicyIssueContainsKeywordsPredicate(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        PolicyIssueContainsKeywordsPredicate firstPredicateCopy =
+                new PolicyIssueContainsKeywordsPredicate(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_policyIssueContainsKeywords_returnsTrue() {
+        // One keyword
+        PolicyIssueContainsKeywordsPredicate predicate =
+                new PolicyIssueContainsKeywordsPredicate("11-11-2023");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY, "11-11-2023", VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Trailing and Leading white spaces
+        predicate = new PolicyIssueContainsKeywordsPredicate("   11-11-2023    ");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY, "11-11-2023", VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Partial keyword
+        predicate = new PolicyIssueContainsKeywordsPredicate("11-11");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY, "11-11-2023", VALID_POLICY_EXPIRY_DATE_AMY).build()));
+    }
+
+    @Test
+    public void test_policyIssueDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keyword
+        PolicyIssueContainsKeywordsPredicate predicate = new PolicyIssueContainsKeywordsPredicate("12-12-2022");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY, "11-11-2023", VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Keyword only matches word that is separated by white space
+        predicate = new PolicyIssueContainsKeywordsPredicate("11 - 11");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY, "11-11-2023", VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Keyword do not match exact
+        predicate = new PolicyIssueContainsKeywordsPredicate("11-11-2022");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                VALID_POLICY_NO_AMY, "11-11-2023", VALID_POLICY_EXPIRY_DATE_AMY).build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "keyword1";
+        PolicyIssueContainsKeywordsPredicate predicate = new PolicyIssueContainsKeywordsPredicate(keyword);
+
+        String expected = PolicyIssueContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=["
+                + keyword + "]}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/PolicyNumberContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/PolicyNumberContainsKeywordsPredicateTest.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_ISSUE_DA
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.policy.PolicyNumber;
 import seedu.address.testutil.PersonBuilder;
 
 public class PolicyNumberContainsKeywordsPredicateTest {
@@ -81,6 +82,15 @@ public class PolicyNumberContainsKeywordsPredicateTest {
         predicate = new PolicyNumberContainsKeywordsPredicate("FWD11234");
         assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
                 "FWD1123", VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+    }
+
+    @Test
+    public void test_policyNumberIsDefault_returnsFalse() {
+        // Policy number is the default parameter
+        PolicyNumberContainsKeywordsPredicate predicate =
+                new PolicyNumberContainsKeywordsPredicate("FWD1123");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, PolicyNumber.DEFAULT_VALUE,
+                VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/predicates/PolicyNumberContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/PolicyNumberContainsKeywordsPredicateTest.java
@@ -1,0 +1,95 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_EXPIRY_DATE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_ISSUE_DATE_AMY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class PolicyNumberContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "first second";
+
+        PolicyNumberContainsKeywordsPredicate firstPredicate =
+                new PolicyNumberContainsKeywordsPredicate(firstPredicateKeyword);
+        PolicyNumberContainsKeywordsPredicate secondPredicate =
+                new PolicyNumberContainsKeywordsPredicate(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        PolicyNumberContainsKeywordsPredicate firstPredicateCopy =
+                new PolicyNumberContainsKeywordsPredicate(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_policyNumberContainsKeywords_returnsTrue() {
+        // One keyword
+        PolicyNumberContainsKeywordsPredicate predicate =
+                new PolicyNumberContainsKeywordsPredicate("FWD1123");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                "FWD1123", VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Trailing and Leading white spaces
+        predicate = new PolicyNumberContainsKeywordsPredicate("   FWD1123    ");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                "FWD1123", VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Mixed-case keywords
+        predicate = new PolicyNumberContainsKeywordsPredicate("fwD1123");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                "FWD1123", VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Partial keyword
+        predicate = new PolicyNumberContainsKeywordsPredicate("FW");
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                "FWD1123", VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+    }
+
+    @Test
+    public void test_policyNumberDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keyword
+        PolicyNumberContainsKeywordsPredicate predicate = new PolicyNumberContainsKeywordsPredicate("ABC999");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                "FWD1123", VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Keyword only matches word that is separated by white space
+        predicate = new PolicyNumberContainsKeywordsPredicate("FWD 11 23");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                "FWD1123", VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+
+        // Keyword do not match exact
+        predicate = new PolicyNumberContainsKeywordsPredicate("FWD11234");
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY,
+                "FWD1123", VALID_POLICY_ISSUE_DATE_AMY, VALID_POLICY_EXPIRY_DATE_AMY).build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "keyword1";
+        PolicyNumberContainsKeywordsPredicate predicate = new PolicyNumberContainsKeywordsPredicate(keyword);
+
+        String expected = PolicyNumberContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=["
+                + keyword + "]}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/RemindPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/RemindPredicateTest.java
@@ -7,8 +7,12 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_ISSUE_DATE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_NO_AMY;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.policy.PolicyDate;
 import seedu.address.testutil.PersonBuilder;
 
 public class RemindPredicateTest {
@@ -38,36 +42,55 @@ public class RemindPredicateTest {
         assertFalse(firstPredicate.equals(secondPredicate));
     }
 
-    // All tests on the test method are done on the date 12/11/2023, and will be using 30 days as the benchmark.
-    // If the tests are going to be done after 12/12/2023, do adjust the expiry dates for testing purposes.
     @Test
     public void test_policyExpiryDateIsWithinUserInputDays_returnsTrue() {
-        // Policy expiry date is 30 days from 12/11/2023
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(PolicyDate.VALIDATION_DATE_FORMAT);
+
+        // Policy expiry date is 30 days away
         RemindPredicate predicate = new RemindPredicate(30);
         assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
-                VALID_POLICY_ISSUE_DATE_AMY, "11-12-2023").build()));
+                VALID_POLICY_ISSUE_DATE_AMY, LocalDate.now().plusDays(30).format(formatter)).build()));
 
-        // Policy expiry date is 60 days away from 12/11/2023
+        // Policy expiry date is 60 days away
         predicate = new RemindPredicate(60);
         assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
-                VALID_POLICY_ISSUE_DATE_AMY, "10-01-2024").build()));
+                VALID_POLICY_ISSUE_DATE_AMY, LocalDate.now().plusDays(60).format(formatter)).build()));
 
-        // Policy expiry date is within 60 days away from 12/11/2023
+        // Policy expiry date is within 60 days away
         assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
-                VALID_POLICY_ISSUE_DATE_AMY, "25-12-2023").build()));
+                VALID_POLICY_ISSUE_DATE_AMY, LocalDate.now().plusDays(15).format(formatter)).build()));
     }
 
     @Test
     public void test_policyExpiryDateIsNotInNext30Days_returnsFalse() {
-        // Policy expiry date is over 30 days away from 12/11/2023
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(PolicyDate.VALIDATION_DATE_FORMAT);
+
+        // Policy expiry date is more than 30 days away
         RemindPredicate predicate = new RemindPredicate(30);
         assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
-                VALID_POLICY_ISSUE_DATE_AMY, "12-12-2024").build()));
+                VALID_POLICY_ISSUE_DATE_AMY, LocalDate.now().plusDays(50).format(formatter)).build()));
+    }
+
+    @Test
+    public void test_policyExpiryDatePassed_returnsFalse() {
+        // Policy expiry date is in the past
+        RemindPredicate predicate = new RemindPredicate(30);
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
+                VALID_POLICY_ISSUE_DATE_AMY, "10-10-2020").build()));
+    }
+
+    @Test
+    public void test_policyExpiryDateIsDefault_returnsFalse() {
+        // Policy expiry date is the default parameter
+        RemindPredicate predicate = new RemindPredicate(30);
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
+                VALID_POLICY_ISSUE_DATE_AMY, PolicyDate.DEFAULT_VALUE).build()));
     }
 
     @Test
     public void toStringMethod() {
         int days = 30;
+
         RemindPredicate predicate = new RemindPredicate(days);
 
         String expected = RemindPredicate.class.getCanonicalName() + "{days=" + days + "}";

--- a/src/test/java/seedu/address/model/person/predicates/RemindPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/RemindPredicateTest.java
@@ -45,7 +45,7 @@ public class RemindPredicateTest {
         // Policy expiry date is 30 days from 12/11/2023
         RemindPredicate predicate = new RemindPredicate(30);
         assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
-                VALID_POLICY_ISSUE_DATE_AMY, "12-12-2023").build()));
+                VALID_POLICY_ISSUE_DATE_AMY, "11-12-2023").build()));
 
         // Policy expiry date is 60 days away from 12/11/2023
         predicate = new RemindPredicate(60);

--- a/src/test/java/seedu/address/model/person/predicates/RemindPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/RemindPredicateTest.java
@@ -1,0 +1,76 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_ISSUE_DATE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_NO_AMY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class RemindPredicateTest {
+
+    @Test
+    public void equals() {
+        int firstPredicateDay = 0;
+        int secondPredicateDay = 30;
+
+        RemindPredicate firstPredicate = new RemindPredicate(firstPredicateDay);
+        RemindPredicate secondPredicate = new RemindPredicate(secondPredicateDay);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        RemindPredicate firstPredicateCopy = new RemindPredicate(firstPredicateDay);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    // All tests on the test method are done on the date 12/11/2023, and will be using 30 days as the benchmark.
+    // If the tests are going to be done after 12/12/2023, do adjust the expiry dates for testing purposes.
+    @Test
+    public void test_policyExpiryDateIsWithinUserInputDays_returnsTrue() {
+        // Policy expiry date is 30 days from 12/11/2023
+        RemindPredicate predicate = new RemindPredicate(30);
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
+                VALID_POLICY_ISSUE_DATE_AMY, "12-12-2023").build()));
+
+        // Policy expiry date is 60 days away from 12/11/2023
+        predicate = new RemindPredicate(60);
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
+                VALID_POLICY_ISSUE_DATE_AMY, "11-01-2024").build()));
+
+        // Policy expiry date is within 60 days away from 12/11/2023
+        assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
+                VALID_POLICY_ISSUE_DATE_AMY, "25-12-2023").build()));
+    }
+
+    @Test
+    public void test_policyExpiryDateIsNotInNext30Days_returnsFalse() {
+        // Policy expiry date is over 30 days away from 12/11/2023
+        RemindPredicate predicate = new RemindPredicate(30);
+        assertFalse(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
+                VALID_POLICY_ISSUE_DATE_AMY, "12-12-2024").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        int days = 30;
+        RemindPredicate predicate = new RemindPredicate(days);
+
+        String expected = RemindPredicate.class.getCanonicalName() + "{days=" + days + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/predicates/RemindPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/RemindPredicateTest.java
@@ -50,7 +50,7 @@ public class RemindPredicateTest {
         // Policy expiry date is 60 days away from 12/11/2023
         predicate = new RemindPredicate(60);
         assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,
-                VALID_POLICY_ISSUE_DATE_AMY, "11-01-2024").build()));
+                VALID_POLICY_ISSUE_DATE_AMY, "10-01-2024").build()));
 
         // Policy expiry date is within 60 days away from 12/11/2023
         assertTrue(predicate.test(new PersonBuilder().withPolicy(VALID_COMPANY_AMY, VALID_POLICY_NO_AMY,

--- a/src/test/java/seedu/address/model/person/predicates/TagContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/TagContainsKeywordsPredicateTest.java
@@ -1,0 +1,80 @@
+package seedu.address.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class TagContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "first second";
+
+        TagContainsKeywordsPredicate firstPredicate = new TagContainsKeywordsPredicate(firstPredicateKeyword);
+        TagContainsKeywordsPredicate secondPredicate = new TagContainsKeywordsPredicate(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TagContainsKeywordsPredicate firstPredicateCopy = new TagContainsKeywordsPredicate(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_tagContainsKeywords_returnsTrue() {
+        // One keyword
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate("friend");
+        assertTrue(predicate.test(new PersonBuilder().withTags("friend", "colleague").build()));
+
+        // Trailing and Leading white spaces
+        predicate = new TagContainsKeywordsPredicate("   friend    ");
+        assertTrue(predicate.test(new PersonBuilder().withTags("friend", "colleague").build()));
+
+        // Mixed-case keywords
+        predicate = new TagContainsKeywordsPredicate("fRiEnd");
+        assertTrue(predicate.test(new PersonBuilder().withTags("friend", "colleague").build()));
+
+        // Partial keyword
+        predicate = new TagContainsKeywordsPredicate("fri");
+        assertTrue(predicate.test(new PersonBuilder().withTags("friend", "colleague").build()));
+    }
+
+    @Test
+    public void test_tagDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keyword
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate("family");
+        assertFalse(predicate.test(new PersonBuilder().withTags("friend", "colleague").build()));
+
+        // Keyword only matches word that is separated by white space
+        predicate = new TagContainsKeywordsPredicate("friend colleague");
+        assertFalse(predicate.test(new PersonBuilder().withTags("friend", "colleague").build()));
+
+        // Keyword do not match exact
+        predicate = new TagContainsKeywordsPredicate("friends");
+        assertFalse(predicate.test(new PersonBuilder().withTags("friend", "colleague").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "keyword1";
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(keyword);
+
+        String expected = TagContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=[" + keyword + "]}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/policy/PolicyTest.java
+++ b/src/test/java/seedu/address/model/policy/PolicyTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.policy;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_AMY;
@@ -52,5 +53,57 @@ public class PolicyTest {
         Policy p4 = new Policy(new Company(VALID_COMPANY_AMY), new PolicyNumber(VALID_POLICY_NO_AMY),
                 new PolicyDate(VALID_POLICY_ISSUE_DATE_AMY), new PolicyDate(VALID_POLICY_EXPIRY_DATE_BOB));
         assertFalse(amyPolicy.equals(p4));
+    }
+
+    @Test
+    public void toDisplay_hasDefaultPolicyParameter_returnsNoPolicyFound() {
+        Policy policyWithDefaultCompany = new Policy(new Company(Company.DEFAULT_VALUE),
+                new PolicyNumber(VALID_POLICY_NO_AMY), new PolicyDate(VALID_POLICY_ISSUE_DATE_AMY),
+                    new PolicyDate(VALID_POLICY_EXPIRY_DATE_AMY));
+        Policy policyWithDefaultPolicyNumber = new Policy(new Company(Company.DEFAULT_VALUE),
+                new PolicyNumber(PolicyNumber.DEFAULT_VALUE), new PolicyDate(VALID_POLICY_ISSUE_DATE_AMY),
+                new PolicyDate(VALID_POLICY_EXPIRY_DATE_AMY));
+        Policy policyWithDefaultPolicyIssue = new Policy(new Company(Company.DEFAULT_VALUE),
+                new PolicyNumber(PolicyNumber.DEFAULT_VALUE), new PolicyDate(PolicyDate.DEFAULT_VALUE),
+                new PolicyDate(VALID_POLICY_EXPIRY_DATE_AMY));
+        Policy policyWithDefaultPolicyExpiry = new Policy(new Company(Company.DEFAULT_VALUE),
+                new PolicyNumber(PolicyNumber.DEFAULT_VALUE), new PolicyDate(VALID_POLICY_ISSUE_DATE_AMY),
+                new PolicyDate(PolicyDate.DEFAULT_VALUE));
+        String expected = "No Policy Found";
+
+        // Company parameter is default, boolean value don't matter -> returns No Policy Found
+        assertEquals(expected, policyWithDefaultCompany.toDisplay(false));
+
+        // Company parameter is default, boolean value don't matter -> returns No Policy Found
+        assertEquals(expected, policyWithDefaultPolicyNumber.toDisplay(false));
+
+        // Company parameter is default, boolean value don't matter -> returns No Policy Found
+        assertEquals(expected, policyWithDefaultPolicyIssue.toDisplay(false));
+
+        // Company parameter is default, boolean value don't matter -> returns No Policy Found
+        assertEquals(expected, policyWithDefaultPolicyExpiry.toDisplay(false));
+    }
+
+    @Test
+    public void toDisplay_isPersonCardIsTrue_returnsCustomisedString() {
+        Policy amyPolicy = new Policy(new Company(VALID_COMPANY_AMY), new PolicyNumber(VALID_POLICY_NO_AMY),
+                new PolicyDate(VALID_POLICY_ISSUE_DATE_AMY), new PolicyDate(VALID_POLICY_EXPIRY_DATE_AMY));
+
+        String expected = "Company: " + VALID_COMPANY_AMY + "\n" + "Policy Number: " + VALID_POLICY_NO_AMY + "\n"
+                + "Policy Issue Date: " + VALID_POLICY_ISSUE_DATE_AMY + "\n" + "Policy Expiry Date: "
+                    + VALID_POLICY_EXPIRY_DATE_AMY;
+
+        assertEquals(expected, amyPolicy.toDisplay(true));
+    }
+
+    @Test
+    public void toDisplay_isPersonCardIsFalse_returnsCustomisedString() {
+        Policy amyPolicy = new Policy(new Company(VALID_COMPANY_AMY), new PolicyNumber(VALID_POLICY_NO_AMY),
+                new PolicyDate(VALID_POLICY_ISSUE_DATE_AMY), new PolicyDate(VALID_POLICY_EXPIRY_DATE_AMY));
+
+        String expected = VALID_COMPANY_AMY + ", " + VALID_POLICY_NO_AMY + ", "
+                + VALID_POLICY_ISSUE_DATE_AMY + ", " + VALID_POLICY_EXPIRY_DATE_AMY;
+
+        assertEquals(expected, amyPolicy.toDisplay(false));
     }
 }


### PR DESCRIPTION
Closes #94

1. Add tests for the other 9 predicates that `find` command uses
2. Add tests for the newly added `remind` command
3. Added `toDisplay` method testing for PolicyTest.java
4. Updated and added tests to current name predicate.