### PR TITLE
Standardize term expiry in documentation

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -284,7 +284,7 @@ The following activity diagram summarises what happens when a user executes the 
 <br>
 
 ### `sort`
-The `sort` command allows the user to view the profiles arranged in order of earliest to latest policy expiration date, with those profiles that have no policy data placed at the end of the late
+The `sort` command allows the user to view the profiles arranged in order of earliest to latest policy expiry date, with those profiles that have no policy data placed at the end of the late
 
 #### Implementation:
 The sorted list will be displayed in the UI. The remind mechanism is facilitated by `Model` through the following operations:
@@ -591,11 +591,11 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case resumes at step 2.
 
-**Use case: UC7 – Get a reminder for clients with approaching policy expiration dates**
+**Use case: UC7 – Get a reminder for clients with approaching policy expiry dates**
 
 **MSS**
 
-1.  User requests to get a reminder for clients with approaching policy expiration dates within a certain number of days.
+1.  User requests to get a reminder for clients with approaching policy expiry dates within a certain number of days.
 2.  InsureIQ filters the list based on the days given.
 3.  InsureIQ shows a confirmation message.
 
@@ -613,7 +613,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **MSS**
 
-1.  User requests to sort clients by policy expiration date.
+1.  User requests to sort clients by policy expiry date.
 2.  InsureIQ sorts the list of clients in the data file from earliest to latest policy expiry date.
 3.  InsureIQ shows a confirmation message that the list was sorted.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -141,7 +141,7 @@ Format: `edit INDEX [n/NAME] [i/NRIC] [p/CONTACT NUMBER] [e/EMAIL] [a/ADDRESS] [
 
 Examples:
 *  `edit 1 l/SNB9876E` updates the policy at the INDEX number 1 with the new licence plate provided.
-*  `edit 2 pn/AB12345J pe/31-12-2024` updates the policy at the INDEX number 2 with the new policy number and expiration date.
+*  `edit 2 pn/AB12345J pe/31-12-2024` updates the policy at the INDEX number 2 with the new policy number and expiry date.
 
 Acceptable values for each parameter:
 * `n/NAME`: Alphanumeric.
@@ -243,11 +243,11 @@ Error: The parameter is not of the type positive integer
 ```
 
 
-### Sorting clients by policy expiration date : `sort`
+### Sorting clients by policy expiry date : `sort`
 
 Format: `sort`
 
-* Sorts the list from earliest to latest policy expiration date.
+* Sorts the list from earliest to latest policy expiry date.
 * People in the list with no policy data will be at the end of the sorted list.
 * The parameter, if any, inputted after `sort` is ignored.
 
@@ -259,9 +259,9 @@ Expected output upon success :
 ![SortSuccess](images/SortSuccess.png)
 
 
-### Remind user of clients policy expiration date : `remind`
+### Remind user of clients policy expiry date : `remind`
 
-Reminds the user of clients that have approaching policy expiration date within a certain number of days.
+Reminds the user of clients that have approaching policy expiry date within a certain number of days.
 
 Format: `remind NUMBER_OF_DAYS`
 

--- a/docs/team/rsxix.md
+++ b/docs/team/rsxix.md
@@ -11,7 +11,7 @@ The user interacts with it using a CLI, and it has a GUI created with JavaFX.
 Given below are my contributions to the project.
 
 * **New Feature**: Added the ability to `sort` the client list.
-    * What it does: Allows the user to `sort` clients based on their policy expiration date, from those expiring earliest to those without policy data.
+    * What it does: Allows the user to `sort` clients based on their policy expiry date, from those expiring earliest to those without policy data.
     * Justification: The feature is useful to car insurance agents who will want to know which policies expiry fast so they can respond appropiately and not risk losing their business.
 
 * **Code contributed**: [RepoSense link](https://nus-cs2103-ay2324s1.github.io/tp-dashboard/?search=RSXIX&breakdown=true)

--- a/src/main/java/seedu/address/logic/parser/BatchDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/BatchDeleteCommandParser.java
@@ -42,7 +42,6 @@ public class BatchDeleteCommandParser implements Parser<BatchDeleteCommand> {
         // else: hasCompany is true, hasDeleteMonth is false
         assert hasCompany : "should has input for company";
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_COMPANY);
-        // seems like no input will trigger line below
         Company company = ParserUtil.parseCompany(argMultimap.getValue(PREFIX_COMPANY).get());
 
         return new BatchDeleteCommand(null, company);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -82,7 +82,7 @@ public interface Model {
     void setPerson(Person target, Person editedPerson);
 
     /**
-     * Sorts the list by policy expiration date
+     * Sorts the list by policy expiry date
      */
     void sortData();
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -84,7 +84,7 @@ public class Person {
     }
 
     /**
-     * Compares the policy issue date to the policy expiration date to see which comes first.
+     * Compares the policy issue date to the policy expiry date to see which comes first.
      * Returns more than 0 if expiry date is later and less than 0 otherwise
      * @return int
      */

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -77,7 +77,7 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
-     * Sorts the people in the list based off the policy expiration date
+     * Sorts the people in the list based off the policy expiry date
      * Those with no policy are at the end of the list
      */
     public void sort() {


### PR DESCRIPTION
Close #248 

Changes `expiration` in documentation to `expiry`